### PR TITLE
更新IP地址的获取方式

### DIFF
--- a/etc/collector.yml
+++ b/etc/collector.yml
@@ -4,7 +4,7 @@ logger:
   keepHours: 2
 identity:
   specify: ""
-  shell: /usr/sbin/ifconfig `/usr/sbin/route|grep '^default'|awk '{print $NF}'`|grep inet|awk '{print $2}'|head -n 1
+  shell: hostname -i
 sys:
   # timeout in ms
   # interval in second


### PR DESCRIPTION
ifconfig 和 route 命令，写绝对路径会导致兼容性不好。
1. Debian系统路径对应： /sbin/ifconfig 和 /sbin/route
2. 原命令获取的IP地址兼容性不好，会带“addr:”在前面。 addr:192.163.10.31
3. 本地配置正确的情况下 `hostname -i`是能拿到正确IP的