### PR TITLE
更新IP地址的获取方式

### DIFF
--- a/etc/index.yml
+++ b/etc/index.yml
@@ -4,4 +4,4 @@ logger:
   keepHours: 2
 identity:
   specify: ""
-  shell: /usr/sbin/ifconfig `/usr/sbin/route|grep '^default'|awk '{print $NF}'`|grep inet|awk '{print $2}'|head -n 1
+  shell: hostname -i


### PR DESCRIPTION
在不同操作系统下全路径不一样，比如上述的 ifconfig / route 在 Debian 系统的 /sbin 目录下。  
另外 Debian 打印出来 多 'addr:' 需要多处理 /sbin/ifconfig `/sbin/route|grep '^default'|awk '{print $NF}'`|grep inet|awk '{print $2}'|awk -F':' '{print $2}'|head -n 1  
还不如直接 hostname -i 获取，正常配置下都Okay的。  