### PR TITLE
更新IP的获取方式

### DIFF
--- a/etc/judge.yml
+++ b/etc/judge.yml
@@ -14,7 +14,7 @@ redis:
 
 identity:
   specify: ""
-  shell: /usr/sbin/ifconfig `/usr/sbin/route|grep '^default'|awk '{print $NF}'`|grep inet|awk '{print $2}'|head -n 1
+  shell: hostname -i 
 
 logger:
   dir: logs/judge


### PR DESCRIPTION
原命令也是基于 路径正确、操作系统输出格式正确，还不如 hostname -i 来得简单。  
hostname -i 在正确配置的操作系统下，都能正常获取IP地址。  
简单高效，简单就是好。