### PR TITLE
delete useless lock

### DIFF
--- a/src/modules/collector/config/config.go
+++ b/src/modules/collector/config/config.go
@@ -3,8 +3,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"sync"
-
 	"github.com/didi/nightingale/src/modules/collector/log/worker"
 	"github.com/didi/nightingale/src/modules/collector/stra"
 	"github.com/didi/nightingale/src/modules/collector/sys"
@@ -24,15 +22,12 @@ type ConfYaml struct {
 
 var (
 	Config   *ConfYaml
-	lock     = new(sync.RWMutex)
 	Endpoint string
 	Cwd      string
 )
 
 // Get configuration file
 func Get() *ConfYaml {
-	lock.RLock()
-	defer lock.RUnlock()
 	return Config
 }
 
@@ -41,9 +36,6 @@ func Parse(conf string) error {
 	if err != nil {
 		return fmt.Errorf("cannot read yml[%s]: %v", conf, err)
 	}
-
-	lock.Lock()
-	defer lock.Unlock()
 
 	viper.SetConfigType("yaml")
 	err = viper.ReadConfig(bytes.NewBuffer(bs))

--- a/src/modules/index/config/config.go
+++ b/src/modules/index/config/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/didi/nightingale/src/modules/index/cache"
 	"github.com/didi/nightingale/src/toolkits/address"
@@ -35,12 +34,9 @@ type RPCSection struct {
 
 var (
 	Config *ConfYaml
-	lock   = new(sync.RWMutex)
 )
 
 func GetCfgYml() *ConfYaml {
-	lock.RLock()
-	defer lock.RUnlock()
 	return Config
 }
 
@@ -49,9 +45,6 @@ func Parse(conf string) error {
 	if err != nil {
 		return fmt.Errorf("cannot read yml[%s]: %v", conf, err)
 	}
-
-	lock.Lock()
-	defer lock.Unlock()
 
 	viper.SetConfigType("yaml")
 	err = viper.ReadConfig(bytes.NewBuffer(bs))

--- a/src/modules/monapi/config/yaml.go
+++ b/src/modules/monapi/config/yaml.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/spf13/viper"
 	"github.com/toolkits/pkg/file"
@@ -87,13 +86,10 @@ type ldapAttributes struct {
 
 var (
 	yaml *Config
-	lock = new(sync.RWMutex)
 )
 
 // Get configuration file
 func Get() *Config {
-	lock.RLock()
-	defer lock.RUnlock()
 	return yaml
 }
 
@@ -153,9 +149,7 @@ func Parse(ymlfile string) error {
 		c.Queue.EventQueues = append(c.Queue.EventQueues, prefix+prios[i])
 	}
 
-	lock.Lock()
 	yaml = &c
-	lock.Unlock()
 
 	return nil
 }

--- a/src/modules/tsdb/config/config.go
+++ b/src/modules/tsdb/config/config.go
@@ -3,8 +3,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"sync"
-
 	"github.com/didi/nightingale/src/modules/tsdb/backend/rpc"
 	"github.com/didi/nightingale/src/modules/tsdb/cache"
 	"github.com/didi/nightingale/src/modules/tsdb/index"
@@ -45,12 +43,9 @@ type RpcSection struct {
 
 var (
 	Config *ConfYaml
-	lock   = new(sync.RWMutex)
 )
 
 func GetCfgYml() *ConfYaml {
-	lock.RLock()
-	defer lock.RUnlock()
 	return Config
 }
 
@@ -59,9 +54,6 @@ func Parse(conf string) error {
 	if err != nil {
 		return fmt.Errorf("cannot read yml[%s]: %v", conf, err)
 	}
-
-	lock.Lock()
-	defer lock.Unlock()
 
 	viper.SetConfigType("yaml")
 	err = viper.ReadConfig(bytes.NewBuffer(bs))


### PR DESCRIPTION
The sync.RWMutex cannot work as you expect as a result of you return the pointer directly.
In these scenarios that don't need to update your configurations regularly, the lock is useless, so delete it.