### PR TITLE
修改adress.go的convPort方法，支持IPv6地址之间建立连接。

### DIFF
--- a/src/toolkits/address/address.go
+++ b/src/toolkits/address/address.go
@@ -40,7 +40,11 @@ func GetRPCPort(mod string) int {
 }
 
 func convPort(module, listen, portType string) int {
-	port, err := strconv.Atoi(strings.Split(listen, ":")[1])
+	splitChar := ":"
+	if IsIPv6(listen) {
+		splitChar = "]:"
+	}
+	port, err := strconv.Atoi(strings.Split(listen, splitChar)[1])
 	if err != nil {
 		fmt.Printf("%s.%s invalid", module, portType)
 		os.Exit(1)
@@ -127,3 +131,8 @@ func getConf() string {
 	os.Exit(1)
 	return ""
 }
+
+func IsIPv6(address string)  bool {
+	return strings.Count(address,":") >=2
+}
+


### PR DESCRIPTION
monapi:
  http: '[::]:5800'
  address:
  - '[::1]'

transfer:
http: '[::]:5810'
rpc: '[::]:5811'
  address:
  - '[::1]'

