### PR TITLE
[transfer] fix and trigger generates event twice bug

### DIFF
--- a/src/modules/monapi/scache/init.go
+++ b/src/modules/monapi/scache/init.go
@@ -232,10 +232,15 @@ func GetLeafNids(nid int64, exclNid []int64) ([]int64, error) {
 		return ids, nil
 	}
 
+	exclLeafIds, err := GetExclLeafIds(exclNid)
+	if err != nil {
+		return leafIds, err
+	}
+
 	for _, id := range ids {
 		idsMap[id] = true
 	}
-	for _, id := range exclNid {
+	for _, id := range exclLeafIds {
 		delete(idsMap, id)
 	}
 
@@ -255,4 +260,20 @@ func removeDuplicateElement(addrs []string) []string {
 		}
 	}
 	return result
+}
+
+// GetExclLeafIds 获取排除节点下的叶子节点
+func GetExclLeafIds(exclNid []int64) (leafIds []int64, err error) {
+	for _, nid := range exclNid {
+		node, err := model.NodeGet("id", nid)
+		if err != nil {
+			return leafIds, err
+		}
+		ids, err := node.LeafIds()
+		if err != nil {
+			return leafIds, err
+		}
+		leafIds = append(leafIds, ids...)
+	}
+	return leafIds, nil
 }

--- a/src/modules/transfer/cron/stra.go
+++ b/src/modules/transfer/cron/stra.go
@@ -76,23 +76,21 @@ func getStrategy() {
 			continue
 		}
 
-		for _, exp := range stra.Exprs {
-			metric := exp.Metric
-			for _, endpoint := range stra.Endpoints {
-				key := str.PK(metric, endpoint) //TODO get straMap key， 此处需要优化
-				k1 := key[0:2]                  //为了加快查找，增加一层 map，key 为计算出来的 hash 的前 2 位
+		metric := stra.Exprs[0].Metric
+		for _, endpoint := range stra.Endpoints {
+			key := str.PK(metric, endpoint) //TODO get straMap key， 此处需要优化
+			k1 := key[0:2]                  //为了加快查找，增加一层 map，key 为计算出来的 hash 的前 2 位
 
-				if _, exists := straMap[k1]; !exists {
-					straMap[k1] = make(map[string][]*model.Stra)
-				}
+			if _, exists := straMap[k1]; !exists {
+				straMap[k1] = make(map[string][]*model.Stra)
+			}
 
-				if _, exists := straMap[k1][key]; !exists {
-					straMap[k1][key] = []*model.Stra{stra}
-					stats.Counter.Set("stra.key", 1)
+			if _, exists := straMap[k1][key]; !exists {
+				straMap[k1][key] = []*model.Stra{stra}
+				stats.Counter.Set("stra.key", 1)
 
-				} else {
-					straMap[k1][key] = append(straMap[k1][key], stra)
-				}
+			} else {
+				straMap[k1][key] = append(straMap[k1][key], stra)
 			}
 		}
 	}


### PR DESCRIPTION
**1. 修复与条件策略生成俩次告警事件的bug**:
**2. 排除节点排除选中节点下所有叶子节点**:

