### PR TITLE
[FIX]修复在查询监控数据时，返回值的step对应不上时间timestamp里面相邻两个时间点的间隔问题，主要发生在180s间隔的数据

### DIFF
--- a/src/modules/tsdb/rpc/query.go
+++ b/src/modules/tsdb/rpc/query.go
@@ -268,6 +268,7 @@ _RETURN_OK:
 
 	if rsize > 2 {
 		realStep = int(resp.Values[1].Timestamp - resp.Values[0].Timestamp)
+		resp.Step = realStep
 	}
 	if rsize > MaxRRAPointCnt || needStep != 0 {
 


### PR DESCRIPTION
**What type of PR is this?**
FIX issue 412的返回值step问题

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->
修复在查询监控数据时的data/ui 接口返回值的step有问题，返回值的step对应不上时间timestamp里面相邻两个时间点的间隔问题，主要发生在180s间隔的数据

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes # 412
https://github.com/didi/nightingale/issues/412
 
**Special notes for your reviewer**: 请 大佬帮忙check下