### PR TITLE
修复metricIndex的TagkvMap初始化两次造成的内存浪费

### DIFF
--- a/src/modules/index/cache/metric_map.go
+++ b/src/modules/index/cache/metric_map.go
@@ -27,7 +27,6 @@ func NewMetricIndex(item dataobj.IndexModel, counter string, now int64) *MetricI
 		Ts:         now,
 	}
 
-	metricIndex.TagkvMap = NewTagkvIndex()
 	for k, v := range item.Tags {
 		metricIndex.TagkvMap.Set(k, v, now)
 	}


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: