### PR TITLE
clean cache, reduce image size

### DIFF
--- a/dockerfiles/n9e/Dockerfile
+++ b/dockerfiles/n9e/Dockerfile
@@ -7,9 +7,9 @@ RUN nightingale/control build
 FROM centos:7
 WORKDIR /home/n9e
 COPY --from=builder /home/n9e/builder/nightingale/ .
-RUN set -ex \
-    && sed -i "s/127.0.0.1:6379/redis:6379/g" `grep -rl "127.0.0.1:6379" ./etc/` && \
-    && sed -i 's/127.0.0.1/mysql/g' etc/mysql.yml
+RUN \
+sed -i "s/127.0.0.1:6379/redis:6379/g" `grep -rl "127.0.0.1:6379" ./etc/` &&\
+sed -i 's/127.0.0.1/mysql/g' etc/mysql.yml
 COPY entrpoint.sh .
 RUN set -ex \
     && yum install mysql net-tools -y \

--- a/dockerfiles/n9e/Dockerfile
+++ b/dockerfiles/n9e/Dockerfile
@@ -7,9 +7,12 @@ RUN nightingale/control build
 FROM centos:7
 WORKDIR /home/n9e
 COPY --from=builder /home/n9e/builder/nightingale/ .
-RUN \
-sed -i "s/127.0.0.1:6379/redis:6379/g" `grep -rl "127.0.0.1:6379" ./etc/` &&\
-sed -i 's/127.0.0.1/mysql/g' etc/mysql.yml
+RUN set -ex \
+    && sed -i "s/127.0.0.1:6379/redis:6379/g" `grep -rl "127.0.0.1:6379" ./etc/` && \
+    && sed -i 's/127.0.0.1/mysql/g' etc/mysql.yml
 COPY entrpoint.sh .
-RUN yum install mysql net-tools -y
+RUN set -ex \
+    && yum install mysql net-tools -y \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 ENTRYPOINT ./entrpoint.sh


### PR DESCRIPTION
**What type of PR is this?**

优化Dockerfile

**What this PR does / why we need it**:
1.  执行 bash 脚本之前最好加上 `set -ex`，因为脚本执行过程中可能会出错，`-e` 在出错时会立即退出， `-x` 会打印出错误调用栈
[GNU手册](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)
2.  用包管理工具安装软件之后应清理缓存，可以减小镜像体积，[Docker文档](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)   In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. ，[参考](https://stackoverflow.com/questions/46089219/how-to-reduce-the-size-of-rhel-centos-fedora-docker-image)

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: