### PR TITLE
[FIX][issue#433]优化告警收敛，查询告警事件统计数据数据时使用created做between查询数据库时耗时非常久的问题，修改为使用etime 可以命中etime索引，提升查询性能，4C8G查询100W告警事件大概9s耗时，修改为etime大概700ms耗时

### DIFF
--- a/src/models/mon_event.go
+++ b/src/models/mon_event.go
@@ -200,8 +200,8 @@ func EventAlertUpgradeUnMarshal(str string) (EventAlertUpgrade, error) {
 	return obj, err
 }
 
-func EventCnt(hashid uint64, stime, etime string, isUpgrade bool) (int64, error) {
-	session := DB["mon"].Where("hashid = ? and event_type = ? and created between ? and ?", hashid, config.ALERT, stime, etime)
+func EventCnt(hashid uint64, stime, etime int64, isUpgrade bool) (int64, error) {
+	session := DB["mon"].Where("hashid = ? and event_type = ? and etime between ? and ?", hashid, config.ALERT, stime, etime)
 
 	if isUpgrade {
 		return session.In("status", GetFlagsByStatus([]string{STATUS_UPGRADE, STATUS_SEND})).Count(new(Event))

--- a/src/modules/monapi/alarm/event_consumer.go
+++ b/src/modules/monapi/alarm/event_consumer.go
@@ -173,7 +173,7 @@ func isInConverge(event *models.Event) bool {
 		startTs = recoveryTs
 	}
 
-	cnt, err := models.EventCnt(event.HashId, models.ParseEtime(startTs), models.ParseEtime(now), event.RealUpgrade)
+	cnt, err := models.EventCnt(event.HashId, startTs, now, event.RealUpgrade)
 	if err != nil {
 		logger.Errorf("get event count failed, err: %v", err)
 		return false


### PR DESCRIPTION
**What type of PR is this?**
优化告警收敛查询数据库中告警事件统计

[FIX][issue#433]优化告警收敛，查询告警事件统计数据数据时使用created做between查询数据库时耗时非常久的问题，修改为使用etime 可以命中etime索引，提升查询性能，4C8G查询100W告警事件大概9s耗时，修改为etime大概700ms耗时
**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes # https://github.com/didi/nightingale/issues/433
 
**Special notes for your reviewer**: @UlricQin @710leo 