### PR TITLE
BUGFIX: 修复短信报警模板的转义问题

### DIFF
--- a/etc/sms.tpl
+++ b/etc/sms.tpl
@@ -7,8 +7,8 @@
 {{end}}监控指标：{{.Metric}}
 指标标签：{{.Tags}}
 当前值：{{.Value}}
-报警说明：{{.Info}}
+报警说明：{{.Info | unescaped}}
 触发时间：{{.Etime}}
-报警详情：{{.Elink}}
-报警策略：{{.Slink}}
-{{if .HasClaim}}认领报警：{{.Clink}}{{end}}
+报警详情：{{.Elink | unescaped}}
+报警策略：{{.Slink | unescaped}}
+{{if .HasClaim}}认领报警：{{.Clink | unescaped}}{{end}}

--- a/etc/sms.tpl
+++ b/etc/sms.tpl
@@ -9,6 +9,6 @@
 当前值：{{.Value}}
 报警说明：{{.Info | unescaped}}
 触发时间：{{.Etime}}
-报警详情：{{.Elink | unescaped}}
-报警策略：{{.Slink | unescaped}}
-{{if .HasClaim}}认领报警：{{.Clink | unescaped}}{{end}}
+报警详情：{{.Elink | urlconvert}}
+报警策略：{{.Slink | urlconvert}}
+{{if .HasClaim}}认领报警：{{.Clink | urlconvert}}{{end}}

--- a/src/modules/monapi/notify/notify.go
+++ b/src/modules/monapi/notify/notify.go
@@ -195,6 +195,9 @@ func genContent(isUpgrade bool, events []*models.Event) (string, string) {
 		smsContent = fmt.Sprintf("InternalServerError: cannot parse %s %v", fp, err)
 	} else {
 		var body bytes.Buffer
+		t = t.Funcs(template.FuncMap{
+			"unescaped": func(str string) interface{} { return template.HTML(str) },
+		})
 		err = t.Execute(&body, values)
 		if err != nil {
 			logger.Errorf("InternalServerError: %v", err)

--- a/src/modules/monapi/notify/notify.go
+++ b/src/modules/monapi/notify/notify.go
@@ -189,15 +189,15 @@ func genContent(isUpgrade bool, events []*models.Event) (string, string) {
 
 	// 生成告警短信，短信和IM复用一个内容模板
 	fp = path.Join(file.SelfDir(), "etc", "sms.tpl")
-	t, err = template.ParseFiles(fp)
+	t, err = template.New("sms-template").Funcs(template.FuncMap{
+		"unescaped":  func(str string) interface{} { return template.HTML(str) },
+		"urlconvert": func(str string) interface{} { return template.URL(str) },
+	}).ParseFiles(fp)
 	if err != nil {
 		logger.Errorf("InternalServerError: cannot parse %s %v", fp, err)
 		smsContent = fmt.Sprintf("InternalServerError: cannot parse %s %v", fp, err)
 	} else {
 		var body bytes.Buffer
-		t = t.Funcs(template.FuncMap{
-			"unescaped": func(str string) interface{} { return template.HTML(str) },
-		})
 		err = t.Execute(&body, values)
 		if err != nil {
 			logger.Errorf("InternalServerError: %v", err)

--- a/src/modules/monapi/notify/notify.go
+++ b/src/modules/monapi/notify/notify.go
@@ -189,7 +189,7 @@ func genContent(isUpgrade bool, events []*models.Event) (string, string) {
 
 	// 生成告警短信，短信和IM复用一个内容模板
 	fp = path.Join(file.SelfDir(), "etc", "sms.tpl")
-	t, err = template.New("sms-template").Funcs(template.FuncMap{
+	t, err = template.New(fp).Funcs(template.FuncMap{
 		"unescaped":  func(str string) interface{} { return template.HTML(str) },
 		"urlconvert": func(str string) interface{} { return template.URL(str) },
 	}).ParseFiles(fp)

--- a/src/modules/monapi/notify/notify.go
+++ b/src/modules/monapi/notify/notify.go
@@ -189,7 +189,7 @@ func genContent(isUpgrade bool, events []*models.Event) (string, string) {
 
 	// 生成告警短信，短信和IM复用一个内容模板
 	fp = path.Join(file.SelfDir(), "etc", "sms.tpl")
-	t, err = template.New(fp).Funcs(template.FuncMap{
+	t, err = template.New("sms.tpl").Funcs(template.FuncMap{
 		"unescaped":  func(str string) interface{} { return template.HTML(str) },
 		"urlconvert": func(str string) interface{} { return template.URL(str) },
 	}).ParseFiles(fp)


### PR DESCRIPTION
BUGFIX:

报警说明里的信息由于 html template 的转义，会将部分字符转义为 html 表示，但是短信内容不需要转义。
向 template 模板添加 unescaped 处理函数，并在模板文件中使用 unescaped 标识不需要转义的字段，实现避免转义

 
**Special notes for your reviewer**: