### PR TITLE
fix: ldap登录如果配置允许coverAttributes，会导致panic

### DIFF
--- a/src/models/user.go
+++ b/src/models/user.go
@@ -112,7 +112,7 @@ func LdapLogin(user, pass string) (*User, error) {
 	if has {
 		if config.Config.LDAP.CoverAttributes {
 			_, err := DB["rdb"].Where("id=?", u.Id).Update(u)
-			return nil, err
+			return &u, err
 		} else {
 			return &u, err
 		}


### PR DESCRIPTION
Signed-off-by: ysicing <i@ysicing.me>

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #453
 
**Special notes for your reviewer**: