### PR TITLE
MOD: agent 文件系统 rw 探测

### DIFF
--- a/src/modules/agent/agent.go
+++ b/src/modules/agent/agent.go
@@ -10,7 +10,6 @@ import (
 	"github.com/didi/nightingale/src/common/loggeri"
 	"github.com/didi/nightingale/src/modules/agent/cache"
 	"github.com/didi/nightingale/src/modules/agent/config"
-	"github.com/didi/nightingale/src/modules/agent/core"
 	"github.com/didi/nightingale/src/modules/agent/http"
 	"github.com/didi/nightingale/src/modules/agent/log/worker"
 	"github.com/didi/nightingale/src/modules/agent/report"
@@ -85,7 +84,6 @@ func main() {
 		udp.Start()
 	}
 
-	core.InitRpcClients()
 	http.Start()
 
 	endingProc()

--- a/src/modules/agent/core/clients.go
+++ b/src/modules/agent/core/clients.go
@@ -12,7 +12,7 @@ type RpcClientContainer struct {
 
 var rpcClients *RpcClientContainer
 
-func InitRpcClients() {
+func init() {
 	rpcClients = &RpcClientContainer{
 		M: make(map[string]*rpc.Client),
 	}

--- a/src/modules/agent/sys/funcs/fsstat.go
+++ b/src/modules/agent/sys/funcs/fsstat.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -68,7 +69,7 @@ func FsRWMetrics() []*dataobj.MetricValue {
 			continue
 		}
 
-		file := filepath.Join(du.FsFile, ".fs-detect")
+		file := filepath.Join(du.FsFile, ".fs-detect."+genRandStr())
 		now := time.Now().Format("2006-01-02 15:04:05")
 		content := "FS-RW" + now
 		err = CheckFS(file, content)
@@ -113,4 +114,21 @@ func CheckFS(file string, content string) error {
 		return err
 	}
 	return nil
+}
+
+func genRandStr() string {
+	const len = 5
+	var letters []byte = []byte("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	randBytes := make([]byte, len)
+	if _, err := rand.Read(randBytes); err != nil {
+		return fmt.Sprintf("%d", rand.Int63())
+	}
+
+	for i := 0; i < len; i++ {
+		pos := randBytes[i] % 62
+		randBytes[i] = letters[pos]
+	}
+
+	return string(randBytes)
 }


### PR DESCRIPTION
探测使用的文件名添加随机字符串后缀，防止使用共享存储的多个机器文件名冲突
顺手改了下 rpcClients 的初始化，使用 init 函数初始化
