### PR TITLE
钉钉告警可以at特定指定人员

### DIFF
--- a/src/modules/rdb/cron/sender_im.go
+++ b/src/modules/rdb/cron/sender_im.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -163,12 +164,20 @@ func sendImByDingTalkRobot(message *dataobj.Message) {
 		}
 	}
 
-	for tokenUser := range set {
-		err := dingtalk.RobotSend(tokenUser, message.Content)
-		if err != nil {
-			logger.Warningf("im dingtalk_robot send to %s fail: %v", tokenUser, err)
+	req := regexp.MustCompile("^1[0-9]{10}$")
+	var atUser []string
+	var tokenUser string
+	for user := range set {
+		if req.MatchString(user){
+			atUser = append(atUser, user)
 		} else {
-			logger.Infof("im dingtalk_robot send to %s succ", tokenUser)
+			tokenUser = user
 		}
+	}
+	err := dingtalk.RobotSend(tokenUser, message.Content, atUser)
+	if err != nil {
+		logger.Warningf("im dingtalk_robot send to %s fail: %v", tokenUser, err)
+	} else {
+		logger.Infof("im dingtalk_robot send to %s succ", tokenUser)
 	}
 }

--- a/src/modules/rdb/cron/sender_im.go
+++ b/src/modules/rdb/cron/sender_im.go
@@ -166,18 +166,20 @@ func sendImByDingTalkRobot(message *dataobj.Message) {
 
 	req := regexp.MustCompile("^1[0-9]{10}$")
 	var atUser []string
-	var tokenUser string
+	var tokenUser []string
 	for user := range set {
 		if req.MatchString(user){
 			atUser = append(atUser, user)
 		} else {
-			tokenUser = user
+			tokenUser = append(tokenUser, user)
 		}
 	}
-	err := dingtalk.RobotSend(tokenUser, message.Content, atUser)
-	if err != nil {
-		logger.Warningf("im dingtalk_robot send to %s fail: %v", tokenUser, err)
-	} else {
-		logger.Infof("im dingtalk_robot send to %s succ", tokenUser)
+	for _, u := range tokenUser {
+		err := dingtalk.RobotSend(u, message.Content, atUser)
+		if err != nil {
+			logger.Warningf("im dingtalk_robot send to %s fail: %v", u, err)
+		} else {
+			logger.Infof("im dingtalk_robot send to %s succ", u)
+		}
 	}
 }

--- a/src/modules/rdb/dingtalk/dingtalk.go
+++ b/src/modules/rdb/dingtalk/dingtalk.go
@@ -16,14 +16,20 @@ type Result struct {
 type dingReqData struct {
 	Msgtype string       `json:"msgtype"`
 	Text    *textContent `json:"text"`
+	At		*atContent `json:"at"`
 }
 
 type textContent struct {
 	Content string `json:"content"`
 }
 
+type atContent struct {
+	AtMobiles []string	`json:"atMobiles"`
+	IsAtAll   bool		`json:"isAtAll"`
+}
+
 // RobotSend robot发送信息
-func RobotSend(tokenUser, sendContent string) error {
+func RobotSend(tokenUser, sendContent string, atUser []string) error {
 	url := "https://oapi.dingtalk.com/robot/send?access_token=" + tokenUser
 
 	dingReqData := new(dingReqData)
@@ -31,6 +37,10 @@ func RobotSend(tokenUser, sendContent string) error {
 	reqContent := new(textContent)
 	reqContent.Content = sendContent
 	dingReqData.Text = reqContent
+	reqAtContent := new(atContent)
+	reqAtContent.IsAtAll = false
+	reqAtContent.AtMobiles = atUser
+	dingReqData.At = reqAtContent
 
 	content, err := json.Marshal(dingReqData)
 	if err != nil {


### PR DESCRIPTION
如果是采取钉钉告警的话，钉钉告警只能通过群聊发送，如果不支持at 别人，人一多容易出现消息没人理的情况。

将特定人员配置为告警接收人，同时对应将个人配置中电话号码填写在IM字段里面，即可在告警时at特定的人。

实现：
增加了dingding机器人at 员工的struct，同时在遍历接受告警人的同时，进行正则匹配，如果匹配到手机号码就append到atUser