### PR TITLE
fix golang build fail in Dockerfile

### DIFF
--- a/dockerfiles/n9e/Dockerfile
+++ b/dockerfiles/n9e/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang as builder
 WORKDIR /home/n9e/builder
-ENV GOPROXY=https://mirrors.aliyun.com/goproxy/
+ENV GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 RUN git clone  https://hub.fastgit.org/didi/nightingale.git
 RUN nightingale/control build
 


### PR DESCRIPTION
What type of PR is this?
这是什么类型的PR？

*  fix golang build fail in Dockerfile
修复了在Dockerfile里面go程序 build 失败问题（阿里云镜像的资源404导致build失败，改成直连资源后解决）