### PR TITLE
add a method to get the Endpoint【增加客户端获取Endpoint的方法】

### DIFF
--- a/src/modules/agent/http/router.go
+++ b/src/modules/agent/http/router.go
@@ -18,6 +18,7 @@ func Config(r *gin.Engine) {
 		v1.GET("/ping", ping)
 		v1.GET("/pid", pid)
 		v1.GET("/addr", addr)
+		v1.GET("/endpoint", endpoint)
 
 		v1.GET("/stra", getStrategy)
 		v1.GET("/cached", getLogCached)

--- a/src/modules/agent/http/router_endpoint.go
+++ b/src/modules/agent/http/router_endpoint.go
@@ -1,0 +1,10 @@
+package http
+
+import (
+	"github.com/didi/nightingale/src/modules/agent/config"
+	"github.com/gin-gonic/gin"
+)
+
+func endpoint(c *gin.Context) {
+	c.String(200, config.Endpoint)
+}


### PR DESCRIPTION
add a method to get the Endpoint
addr: http://agent_host:port/v1/endpoint

增加了一个方法让客户端可以获得endpoint
接口地址：http://agent_host:port/v1/endpoint