### PR TITLE
MOD: 生效 prober promethues 监控的 summary 指标

### DIFF
--- a/etc/plugins/prometheus.yml
+++ b/etc/plugins/prometheus.yml
@@ -1,0 +1,1 @@
+mode: all

--- a/src/modules/prober/manager/accumulator/accumulator.go
+++ b/src/modules/prober/manager/accumulator/accumulator.go
@@ -160,10 +160,11 @@ func (p *accumulator) makeMetric(metric telegraf.Metric) []*dataobj.MetricValue 
 	switch metric.Type() {
 	case telegraf.Counter:
 		return makeCounter(metric, tags)
-	case telegraf.Summary, telegraf.Histogram:
-		logger.Debugf("unsupported type summary, histogram, skip")
+	case telegraf.Summary:
+		return makeSummary(metric, tags)
+	case telegraf.Histogram:
+		logger.Debugf("unsupported type histogram, skip")
 		return nil
-		// return makeSummary(metric, tags)
 	default:
 		return makeGauge(metric, tags)
 	}


### PR DESCRIPTION
已有 summary 指标生成的函数，仅操作生效
添加 promethues 配置文件，使 prober 上报生效