### PR TITLE
perf: control command support mod name with n9e- prefix

### DIFF
--- a/control
+++ b/control
@@ -206,9 +206,10 @@ exec()
   params=${@:2}
 
   if [ ${#2} -gt 0 ]; then
-    for param in $params
+    for mod in $params
     do
-      $1 $param
+      mod=${mod#n9e-}
+      $1 $mod
       if [ "x${mod}" = "xall" ]; then
         break
       fi


### PR DESCRIPTION
**What type of PR is this?**
improve and bugfix

**What this PR does / why we need it**:
1. 提升运行control命令体验，用户经常会习惯使用tab来键入要操作的模块文件名
2. 修复exec函数中mod变量错误

**Which issue(s) this PR fixes**:

 
**Special notes for your reviewer**: