### PR TITLE
perf: mem and disk size calc from %d to %.1f

### DIFF
--- a/etc/agentd.yml
+++ b/etc/agentd.yml
@@ -43,8 +43,8 @@ report:
 
   fields:
     cpu: cat /proc/cpuinfo | grep processor | wc -l
-    mem: cat /proc/meminfo | grep MemTotal | awk '{printf "%dGi", $2/1024/1024}'
-    disk: df -m | grep '/dev/' | grep -v '/var/lib' | grep -v tmpfs | awk '{sum += $2};END{printf "%dGi", sum/1024}'
+    mem: cat /proc/meminfo | grep MemTotal | awk '{printf "%.1fGi", $2/1024/1024}'
+    disk: df -m | grep '/dev/' | grep -v '/var/lib' | grep -v tmpfs | awk '{sum += $2};END{printf "%.1fGi", sum/1024}'
 
 sys:
   # timeout in ms


### PR DESCRIPTION
**What type of PR is this?**
perf

**What this PR does / why we need it**:
目前计算内存和硬盘的时候，直接取整数部分偏差较大，如4G内存，得到Gi为3.7Gi，但目前只显示3Gi差得太多

**Which issue(s) this PR fixes**:

 
**Special notes for your reviewer**: