### PR TITLE
1.修复因重启n9e-server导致LastEvent丢失，无法发送告警恢复问题；2.并发处理event_reader,增强告警处理性能

### DIFF
--- a/sql/n9e_mon.sql
+++ b/sql/n9e_mon.sql
@@ -135,9 +135,7 @@ create table `event` (
   KEY `idx_sid` (`sid`),
   KEY `idx_hashid` (`hashid`),
   KEY `idx_node_path` (`node_path`),
-  KEY `idx_etime` (`etime`),
-  KEY `idx_event_type` (`event_type`),
-  KEY `idx_status` (`status`)
+  KEY `idx_etime_hashid_type_status` (`etime`,`hashid`,`event_type`,`status`)
 ) engine=innodb default charset=utf8 comment 'event';
 
 CREATE TABLE `stra` (

--- a/sql/upgrade/n9e_mon-v4.0.4.sql
+++ b/sql/upgrade/n9e_mon-v4.0.4.sql
@@ -1,0 +1,8 @@
+set names utf8;
+use n9e_mon;
+
+drop index idx_etime on event;
+drop index idx_event_type on event;
+drop index idx_status on event;
+
+ALTER TABLE event ADD INDEX `idx_etime_hashid_type_status` (`etime`,`hashid`,`event_type`,`status`);

--- a/src/models/mon_event_cur.go
+++ b/src/models/mon_event_cur.go
@@ -245,6 +245,12 @@ func EventCurGet(col string, value interface{}) (*EventCur, error) {
 	return &obj, nil
 }
 
+func AllEventCurGet() ([]EventCur, error) {
+	var obj []EventCur
+	err := DB["mon"].Find(&obj)
+	return obj, err
+}
+
 func (e *EventCur) EventIgnore() error {
 	return EventCurDelById(e.Id)
 }

--- a/src/models/node.go
+++ b/src/models/node.go
@@ -24,6 +24,7 @@ type Node struct {
 	Creator     string    `json:"creator"`
 	LastUpdated time.Time `json:"last_updated" xorm:"<-"`
 	Admins      []User    `json:"admins" xorm:"-"`
+	LeafNids    []int64   `json:"leafNids" xorm:"-"`
 }
 
 func (n *Node) FilterMyChildren(nodes []Node) []Node {

--- a/src/modules/server/cache/init.go
+++ b/src/modules/server/cache/init.go
@@ -18,6 +18,13 @@ var ActiveJudgeNode = NewNodeMap()
 const CHECK_INTERVAL = 9
 
 func Init(regions []string) {
+	TreeNodeCache = NewTreeNodeCache()
+	go SyncTreeNodes()
+
+	// 初始化每个node下的所有主机ident
+	NodeIdentsMapCache = NewNodeIdentsMapCache()
+	go SyncIdentsOfNode()
+
 	// 初始化默认参数
 	StraCache = NewStraCache()
 	CollectCache = NewCollectCache()
@@ -30,7 +37,6 @@ func Init(regions []string) {
 	TeamUsersCache = NewTeamUsersCache()
 	TeamCache = NewTeamCache()
 	UserCache = NewUserCache()
-	TreeNodeCache = NewTreeNodeCache()
 
 	LoadMetrics()
 
@@ -46,6 +52,10 @@ func Init(regions []string) {
 	Strategy = NewStrategyMap()
 	NodataStra = NewStrategyMap()
 	SeriesMap = NewIndexMap()
+
+	//周期缓存当前所有告警
+	HashIdEventCurMapCache = NewHashIdEventCurMapCache()
+	go SyncHashIdEventCur()
 
 	//rdb
 	Start()

--- a/src/modules/server/cache/monapi_event_cur.go
+++ b/src/modules/server/cache/monapi_event_cur.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"github.com/toolkits/pkg/logger"
+
+	"sync"
+	"time"
+
+	"github.com/didi/nightingale/v4/src/models"
+)
+
+type HashIdEventCurMap struct {
+	sync.RWMutex
+	Data map[uint64]*models.EventCur
+}
+
+var HashIdEventCurMapCache *HashIdEventCurMap
+
+func NewHashIdEventCurMapCache() *HashIdEventCurMap {
+	return &HashIdEventCurMap{Data: make(map[uint64]*models.EventCur)}
+}
+
+func (t *HashIdEventCurMap) GetBy(hashid uint64) *models.EventCur {
+	t.RLock()
+	defer t.RUnlock()
+
+	return t.Data[hashid]
+}
+
+func (t *HashIdEventCurMap) SetAll(objs map[uint64]*models.EventCur) {
+	t.Lock()
+	defer t.Unlock()
+
+	t.Data = objs
+	return
+}
+
+func SyncHashIdEventCur() {
+	t1 := time.NewTicker(time.Duration(60) * time.Second)
+
+	syncHashIdEventCur()
+	logger.Info("[cron] sync HashIdEventCur cron start...")
+	for {
+		<-t1.C
+		logger.Info("[cron] sync HashIdEventCur start...")
+		syncHashIdEventCur()
+		logger.Info("[cron] sync HashIdEventCur end...")
+
+	}
+}
+
+func syncHashIdEventCur() {
+	allEventCur, err := models.AllEventCurGet()
+	if err != nil {
+		logger.Warningf("get all EventCur err:%v %v", err)
+		return
+	}
+
+	allEventCurMap := make(map[uint64]*models.EventCur)
+	for _, v := range allEventCur {
+		allEventCurMap[v.HashId] = &v
+	}
+
+	HashIdEventCurMapCache.SetAll(allEventCurMap)
+}

--- a/src/modules/server/cache/node_idents.go
+++ b/src/modules/server/cache/node_idents.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"github.com/toolkits/pkg/logger"
+
+	"sync"
+	"time"
+
+	"github.com/didi/nightingale/v4/src/models"
+)
+
+type NodeIdentsMap struct {
+	sync.RWMutex
+	Data map[int64][]string
+}
+
+var NodeIdentsMapCache *NodeIdentsMap
+
+func NewNodeIdentsMapCache() *NodeIdentsMap {
+	return &NodeIdentsMap{Data: make(map[int64][]string)}
+}
+
+func (t *NodeIdentsMap) GetBy(id int64) []string {
+	t.RLock()
+	defer t.RUnlock()
+
+	return t.Data[id]
+}
+
+func (t *NodeIdentsMap) SetAll(objs map[int64][]string) {
+	t.Lock()
+	defer t.Unlock()
+
+	t.Data = objs
+	return
+}
+
+func SyncIdentsOfNode() {
+	t1 := time.NewTicker(time.Duration(60) * time.Second)
+
+	syncIdentsOfNode()
+	logger.Info("[cron] sync IdentsOfNode cron start...")
+	for {
+		<-t1.C
+		logger.Info("[cron] sync IdentsOfNode start...")
+		syncIdentsOfNode()
+		logger.Info("[cron] sync IdentsOfNode end...")
+
+	}
+}
+
+func syncIdentsOfNode() {
+	allNode, err := models.NodeGets("")
+	if err != nil {
+		logger.Warningf("get all Node err:%v %v", err)
+		return
+	}
+
+	nodeIdentsMap := make(map[int64][]string)
+	for i, _ := range allNode {
+		nids, err := models.GetLeafNidsForMon(allNode[i].Id, []int64{})
+		if err != nil {
+			logger.Errorf("err: %v,cache GetLeafNidsForMon by node id: %+v", err, allNode[i].Id)
+		}
+		rids, err := models.ResIdsGetByNodeIds(nids)
+		if err != nil {
+			logger.Errorf("err: %v,ResIdsGetByNodeIds node id: %+v", err, nids)
+		}
+
+		idents, err := models.ResourceIdentsByIds(rids)
+		if err != nil {
+			logger.Errorf("err: %v,ResourceIdentsByIds resource id: %+v", err, rids)
+		}
+		nodeIdentsMap[allNode[i].Id] = idents
+	}
+
+	NodeIdentsMapCache.SetAll(nodeIdentsMap)
+}

--- a/src/modules/server/judge/judge.go
+++ b/src/modules/server/judge/judge.go
@@ -427,6 +427,13 @@ func sendEventIfNeed(status []bool, event *dataobj.Event, stra *models.Stra) {
 			sendEvent(event)
 			stats.Counter.Set("event.recover", 1)
 		}
+
+		// 如果LastEvent不存在，但当前告警表有该告警则发送恢复（场景为处于告警状态，n9e_server重启导致LastEvent缓存丢失）
+		if !exists && cache.HashIdEventCurMapCache.GetBy(event.Hashid) != nil {
+			event.EventType = EVENT_RECOVER
+			sendEvent(event)
+			stats.Counter.Set("event.recover", 1)
+		}
 	}
 }
 


### PR DESCRIPTION
1.修复因重启n9e-server导致LastEvent丢失，新上报数据未触发告警，导致无法发送告警恢复问题；2.并发处理event_reader,增强告警处理性能