### PR TITLE
修复 agent 所在系统有多个网卡启动失败问题

### DIFF
--- a/etc/identity.yml
+++ b/etc/identity.yml
@@ -1,9 +1,9 @@
 # 用来做心跳，给服务端上报本机ip
 ip:
   specify: ""
-  shell: ifconfig `route|grep '^default'|awk '{print $NF}'`|grep inet|awk '{print $2}'|head -n 1
+  shell: ifconfig `route|grep '^default'|awk '{print $NF}'|head -n 1`|grep inet|awk '{print $2}'|head -n 1
 
 # MON、JOB的客户端拿来做本机标识
 ident:
   specify: ""
-  shell: ifconfig `route|grep '^default'|awk '{print $NF}'`|grep inet|awk '{print $2}'|head -n 1
+  shell: ifconfig `route|grep '^default'|awk '{print $NF}'|head -n 1`|grep inet|awk '{print $2}'|head -n 1


### PR DESCRIPTION
修复 agent 所在系统有多个网卡启动失败问题

**What type of PR is this?**
修复问题

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->
修复 agent 启动失败问题。

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
当系统内有多个网卡，`route` 命令可能会获取到多个默认路由：

```
[root@xxx etc]# route|grep '^default'
default         gateway         0.0.0.0         UG    100    0        0 eth0
default         gateway         0.0.0.0         UG    101    0        0 eth1
```

此时会导致命令执行失败：

```
[root@xxx etc]# route|grep '^default'|awk '{print $NF}'
eth0
eth1
[root@xxxetc]# ifconfig `route|grep '^default'|awk '{print $NF}'`
eth1: Unknown host
ifconfig: `--help' gives usage information.
```

添加 `head -n 1` 使用第一个网卡可正常启动。

```
[root@xxx etc]# ifconfig `route|grep '^default'|awk '{print $NF}'|head -n 1`
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
	...
```

**Special notes for your reviewer**:
