### PR TITLE
Config.Heartbeat.LocalAddr  and arm build bug fix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -140,10 +140,13 @@ func Parse() error {
 			fmt.Println("heartbeat ip auto got is blank")
 			os.Exit(1)
 		}
-		port := strings.Split(Config.RPC.Listen, ":")[1]
-		endpoint := Config.Heartbeat.IP + ":" + port
-		Config.Heartbeat.LocalAddr = endpoint
+
 	}
+	// 用户在配置文件中指定了heartbeat.ip ，用于本机没有网络，下面的报错，那么需要将Config.Heartbeat.LocalAddr设置一下
+	// auto get outbound ip fail: dial udp 8.8.8.8:80: connect: network is unreachable
+
+	port := strings.Split(Config.RPC.Listen, ":")[1]
+	Config.Heartbeat.LocalAddr = Config.Heartbeat.IP + ":" + port
 
 	// 正常情况肯定不是127.0.0.1，但是，如果就是单机部署，并且这个机器没有网络，比如本地调试并且本机没网的时候
 	// if Config.Heartbeat.IP == "127.0.0.1" {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-ldap/ldap/v3 v3.2.4
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/snappy v0.0.2
+	github.com/golang/snappy v0.0.3
 	github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99 // indirect
 	github.com/gorilla/sessions v1.2.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,9 @@ github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=


### PR DESCRIPTION
1.  set Config.Heartbeat.LocalAddr when ip can not fetch by auto detect 
2.  upgrade snappy to v0.0.3 to avoid the following failure on Go 1.16