### PR TITLE
ADD: 支持 prometheus 存储

### DIFF
--- a/etc/server.yml
+++ b/etc/server.yml
@@ -22,7 +22,7 @@ tokens:
   - ams-builtin-token
 
 redis:
-  # as queue 
+  # as queue
   local:
     enable: true
     addr: 127.0.0.1:6379
@@ -32,7 +32,6 @@ redis:
       conn: 500
       read: 3000
       write: 3000
-
 
 rdb:
   # for ldap authorization
@@ -90,15 +89,14 @@ rdb:
   #    phone: "phone"
   #    im: ""
   #  coverAttributes: false
-  #  stateExpiresIn: 300    
+  #  stateExpiresIn: 300
   #auth:
   #  captcha: false
-  #  extraMode: 
+  #  extraMode:
   #    enable: false        # enable whiteList, login retry lock, userControl, ...
   #    whiteList: false
   #    frozenDays: 90      # frozen time (day)
   #    writenOffDays: 365  # writenOff time (day)
-
 
 #i18n:
 #  lang: zh
@@ -120,11 +118,11 @@ transfer:
       namespace: "default"
       seriesLimit: 0
       docsLimit: 0
-      daysLimit: 7                               # max query time
+      daysLimit: 7 # max query time
 
       # https://m3db.github.io/m3/m3db/architecture/consistencylevels/
-      writeConsistencyLevel: "majority"          # one|majority|all
-      readConsistencyLevel: "unstrict_majority"  # one|unstrict_majority|majority|all
+      writeConsistencyLevel: "majority" # one|majority|all
+      readConsistencyLevel: "unstrict_majority" # one|unstrict_majority|majority|all
       writeTimeout: 5s
       fetchTimeout: 5s
       connectTimeout: 5s
@@ -144,6 +142,18 @@ transfer:
               #  caCrtPath: /etc/etcd/certs/ca.pem
               #  crtPath: /etc/etcd/certs/etcd-client.pem
               #  keyPath: /etc/etcd/certs/etcd-client-key.pem
+    #prom:
+    #  enabled: true
+    #  name: "prom"
+    #  batch: 10000
+    #  remoteRead:
+    #    - name: prometheus-http
+    #      url: http://172.17.0.3:8428
+    #      remote_timeout: 1s
+    #  remoteWrite:
+    #    - name: prometheus-remotewrite
+    #      url: http://172.17.0.3:8428/api/v1/write
+    #      remote_timeout: 1s
     #tsdb:
     #  enabled: false
     #  name: "tsdb"
@@ -168,7 +178,7 @@ monapi:
   alarmEnabled: true
   region:
     - default
-  
+
   # clean history event
   cleaner:
     # retention days
@@ -178,7 +188,7 @@ monapi:
   notify:
     p1: ["voice", "sms", "mail", "im"]
     p2: ["sms", "mail", "im"]
-    p3: ["mail", "im"]  
+    p3: ["mail", "im"]
 
   # addresses accessible using browser
   link:
@@ -188,12 +198,12 @@ monapi:
 
 judge:
   query:
-    maxConn:          2000
-    maxIdle:          100
-    connTimeout:      1000
-    callTimeout:      2000
+    maxConn: 2000
+    maxIdle: 100
+    connTimeout: 1000
+    callTimeout: 2000
     indexCallTimeout: 2000
-    indexMod:         server
+    indexMod: server
 
 wechat:
   corp_id: "xxxxxxxxxxxxx"

--- a/go.mod
+++ b/go.mod
@@ -16,18 +16,24 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-ping/ping v0.0.0-20201115131931-3300c582a663
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/golang/protobuf v1.3.5
+	github.com/golang/snappy v0.0.2
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hpcloud/tail v1.0.0
 	github.com/influxdata/influxdb v1.8.0
 	github.com/influxdata/telegraf v1.17.2
 	github.com/jackc/pgx v3.6.0+incompatible
+	github.com/json-iterator/go v1.1.9
 	github.com/lib/pq v1.6.0
 	github.com/m3db/m3 v0.15.17
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-sqlite3 v1.14.0 // indirect
 	github.com/mojocn/base64Captcha v1.3.1
 	github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f // indirect
+	github.com/prometheus/client_golang v1.5.1
+	github.com/prometheus/common v0.9.1
+	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/robfig/go-cache v0.0.0-20130306151617-9fc39e0dbf62 // indirect
 	github.com/shirou/gopsutil v3.20.11+incompatible // indirect
 	github.com/spaolacci/murmur3 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgj
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
+github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -736,6 +738,7 @@ github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE
 github.com/multiplay/go-ts3 v1.0.0/go.mod h1:14S6cS3fLNT3xOytrA/DkRyAFNuQLMLEqOYAsf87IbQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=

--- a/src/modules/server/backend/prom/api.go
+++ b/src/modules/server/backend/prom/api.go
@@ -1,0 +1,992 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1 provides bindings to the Prometheus HTTP API v1:
+// http://prometheus.io/docs/querying/api/
+package prom
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+func init() {
+	json.RegisterTypeEncoderFunc("model.SamplePair", marshalPointJSON, marshalPointJSONIsEmpty)
+	json.RegisterTypeDecoderFunc("model.SamplePair", unMarshalPointJSON)
+}
+
+func unMarshalPointJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	p := (*model.SamplePair)(ptr)
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair must be [timestamp, value]")
+		return
+	}
+	t := iter.ReadNumber()
+	if err := p.Timestamp.UnmarshalJSON([]byte(t)); err != nil {
+		iter.ReportError("unmarshal model.SamplePair", err.Error())
+		return
+	}
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair missing value")
+		return
+	}
+
+	f, err := strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		iter.ReportError("unmarshal model.SamplePair", err.Error())
+		return
+	}
+	p.Value = model.SampleValue(f)
+
+	if iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair has too many values, must be [timestamp, value]")
+		return
+	}
+}
+
+func marshalPointJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	p := *((*model.SamplePair)(ptr))
+	stream.WriteArrayStart()
+	// Write out the timestamp as a float divided by 1000.
+	// This is ~3x faster than converting to a float.
+	t := int64(p.Timestamp)
+	if t < 0 {
+		stream.WriteRaw(`-`)
+		t = -t
+	}
+	stream.WriteInt64(t / 1000)
+	fraction := t % 1000
+	if fraction != 0 {
+		stream.WriteRaw(`.`)
+		if fraction < 100 {
+			stream.WriteRaw(`0`)
+		}
+		if fraction < 10 {
+			stream.WriteRaw(`0`)
+		}
+		stream.WriteInt64(fraction)
+	}
+	stream.WriteMore()
+	stream.WriteRaw(`"`)
+
+	// Taken from https://github.com/json-iterator/go/blob/master/stream_float.go#L71 as a workaround
+	// to https://github.com/json-iterator/go/issues/365 (jsoniter, to follow json standard, doesn't allow inf/nan)
+	buf := stream.Buffer()
+	abs := math.Abs(float64(p.Value))
+	fmt := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if abs < 1e-6 || abs >= 1e21 {
+			fmt = 'e'
+		}
+	}
+	buf = strconv.AppendFloat(buf, float64(p.Value), fmt, -1, 64)
+	stream.SetBuffer(buf)
+
+	stream.WriteRaw(`"`)
+	stream.WriteArrayEnd()
+
+}
+
+func marshalPointJSONIsEmpty(ptr unsafe.Pointer) bool {
+	return false
+}
+
+const (
+	statusAPIError = 422
+
+	apiPrefix = "/api/v1"
+
+	epAlerts          = apiPrefix + "/alerts"
+	epAlertManagers   = apiPrefix + "/alertmanagers"
+	epQuery           = apiPrefix + "/query"
+	epQueryRange      = apiPrefix + "/query_range"
+	epLabels          = apiPrefix + "/labels"
+	epLabelValues     = apiPrefix + "/label/:name/values"
+	epSeries          = apiPrefix + "/series"
+	epTargets         = apiPrefix + "/targets"
+	epTargetsMetadata = apiPrefix + "/targets/metadata"
+	epMetadata        = apiPrefix + "/metadata"
+	epRules           = apiPrefix + "/rules"
+	epSnapshot        = apiPrefix + "/admin/tsdb/snapshot"
+	epDeleteSeries    = apiPrefix + "/admin/tsdb/delete_series"
+	epCleanTombstones = apiPrefix + "/admin/tsdb/clean_tombstones"
+	epConfig          = apiPrefix + "/status/config"
+	epFlags           = apiPrefix + "/status/flags"
+)
+
+// AlertState models the state of an alert.
+type AlertState string
+
+// ErrorType models the different API error types.
+type ErrorType string
+
+// HealthStatus models the health status of a scrape target.
+type HealthStatus string
+
+// RuleType models the type of a rule.
+type RuleType string
+
+// RuleHealth models the health status of a rule.
+type RuleHealth string
+
+// MetricType models the type of a metric.
+type MetricType string
+
+const (
+	// Possible values for AlertState.
+	AlertStateFiring   AlertState = "firing"
+	AlertStateInactive AlertState = "inactive"
+	AlertStatePending  AlertState = "pending"
+
+	// Possible values for ErrorType.
+	ErrBadData     ErrorType = "bad_data"
+	ErrTimeout     ErrorType = "timeout"
+	ErrCanceled    ErrorType = "canceled"
+	ErrExec        ErrorType = "execution"
+	ErrBadResponse ErrorType = "bad_response"
+	ErrServer      ErrorType = "server_error"
+	ErrClient      ErrorType = "client_error"
+
+	// Possible values for HealthStatus.
+	HealthGood    HealthStatus = "up"
+	HealthUnknown HealthStatus = "unknown"
+	HealthBad     HealthStatus = "down"
+
+	// Possible values for RuleType.
+	RuleTypeRecording RuleType = "recording"
+	RuleTypeAlerting  RuleType = "alerting"
+
+	// Possible values for RuleHealth.
+	RuleHealthGood    = "ok"
+	RuleHealthUnknown = "unknown"
+	RuleHealthBad     = "err"
+
+	// Possible values for MetricType
+	MetricTypeCounter        MetricType = "counter"
+	MetricTypeGauge          MetricType = "gauge"
+	MetricTypeHistogram      MetricType = "histogram"
+	MetricTypeGaugeHistogram MetricType = "gaugehistogram"
+	MetricTypeSummary        MetricType = "summary"
+	MetricTypeInfo           MetricType = "info"
+	MetricTypeStateset       MetricType = "stateset"
+	MetricTypeUnknown        MetricType = "unknown"
+)
+
+// Error is an error returned by the API.
+type Error struct {
+	Type   ErrorType
+	Msg    string
+	Detail string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Msg)
+}
+
+// Range represents a sliced time range.
+type Range struct {
+	// The boundaries of the time range.
+	Start, End time.Time
+	// The maximum time between two slices within the boundaries.
+	Step time.Duration
+}
+
+const (
+	DefaultStep = 30 * time.Second
+	MaxPoints   = 30000
+)
+
+func (r *Range) Validate() bool {
+	if r.Step <= 0 {
+		r.Step = DefaultStep
+	}
+
+	if !r.End.After(r.Start) {
+		return false
+	}
+
+	dur := r.End.Sub(r.Start)
+
+	for dur/r.Step > MaxPoints {
+		if r.Step < time.Second {
+			r.Step *= 10
+			continue
+		}
+		if r.Step < time.Hour {
+			r.Step *= 60
+			continue
+		}
+
+		r.Step *= 2
+	}
+
+	return true
+}
+
+// API provides bindings for Prometheus's v1 API.
+type API interface {
+	// Alerts returns a list of all active alerts.
+	Alerts(ctx context.Context) (AlertsResult, error)
+	// AlertManagers returns an overview of the current state of the Prometheus alert manager discovery.
+	AlertManagers(ctx context.Context) (AlertManagersResult, error)
+	// CleanTombstones removes the deleted data from disk and cleans up the existing tombstones.
+	CleanTombstones(ctx context.Context) error
+	// Config returns the current Prometheus configuration.
+	Config(ctx context.Context) (ConfigResult, error)
+	// DeleteSeries deletes data for a selection of series in a time range.
+	DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error
+	// Flags returns the flag values that Prometheus was launched with.
+	Flags(ctx context.Context) (FlagsResult, error)
+	// LabelNames returns all the unique label names present in the block in sorted order.
+	LabelNames(ctx context.Context) ([]string, Warnings, error)
+	// LabelValues performs a query for the values of the given label.
+	LabelValues(ctx context.Context, label string, matchs []string) (model.LabelValues, Warnings, error)
+	// Query performs a query for the given time.
+	Query(ctx context.Context, query string, ts time.Time) (model.Value, Warnings, error)
+	// QueryRange performs a query for the given range.
+	QueryRange(ctx context.Context, query string, r Range) (model.Value, Warnings, error)
+	// Series finds series by label matchers.
+	Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, Warnings, error)
+	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
+	// under the TSDB's data directory and returns the directory as response.
+	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
+	// Rules returns a list of alerting and recording rules that are currently loaded.
+	Rules(ctx context.Context) (RulesResult, error)
+	// Targets returns an overview of the current state of the Prometheus target discovery.
+	Targets(ctx context.Context) (TargetsResult, error)
+	// TargetsMetadata returns metadata about metrics currently scraped by the target.
+	TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]MetricMetadata, error)
+	// Metadata returns metadata about metrics currently scraped by the metric name.
+	Metadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error)
+}
+
+// AlertsResult contains the result from querying the alerts endpoint.
+type AlertsResult struct {
+	Alerts []Alert `json:"alerts"`
+}
+
+// AlertManagersResult contains the result from querying the alertmanagers endpoint.
+type AlertManagersResult struct {
+	Active  []AlertManager `json:"activeAlertManagers"`
+	Dropped []AlertManager `json:"droppedAlertManagers"`
+}
+
+// AlertManager models a configured Alert Manager.
+type AlertManager struct {
+	URL string `json:"url"`
+}
+
+// ConfigResult contains the result from querying the config endpoint.
+type ConfigResult struct {
+	YAML string `json:"yaml"`
+}
+
+// FlagsResult contains the result from querying the flag endpoint.
+type FlagsResult map[string]string
+
+// SnapshotResult contains the result from querying the snapshot endpoint.
+type SnapshotResult struct {
+	Name string `json:"name"`
+}
+
+// RulesResult contains the result from querying the rules endpoint.
+type RulesResult struct {
+	Groups []RuleGroup `json:"groups"`
+}
+
+// RuleGroup models a rule group that contains a set of recording and alerting rules.
+type RuleGroup struct {
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Interval float64 `json:"interval"`
+	Rules    Rules   `json:"rules"`
+}
+
+// Recording and alerting rules are stored in the same slice to preserve the order
+// that rules are returned in by the API.
+//
+// Rule types can be determined using a type switch:
+//   switch v := rule.(type) {
+//   case RecordingRule:
+//   	fmt.Print("got a recording rule")
+//   case AlertingRule:
+//   	fmt.Print("got a alerting rule")
+//   default:
+//   	fmt.Printf("unknown rule type %s", v)
+//   }
+type Rules []interface{}
+
+// AlertingRule models a alerting rule.
+type AlertingRule struct {
+	Name        string         `json:"name"`
+	Query       string         `json:"query"`
+	Duration    float64        `json:"duration"`
+	Labels      model.LabelSet `json:"labels"`
+	Annotations model.LabelSet `json:"annotations"`
+	Alerts      []*Alert       `json:"alerts"`
+	Health      RuleHealth     `json:"health"`
+	LastError   string         `json:"lastError,omitempty"`
+}
+
+// RecordingRule models a recording rule.
+type RecordingRule struct {
+	Name      string         `json:"name"`
+	Query     string         `json:"query"`
+	Labels    model.LabelSet `json:"labels,omitempty"`
+	Health    RuleHealth     `json:"health"`
+	LastError string         `json:"lastError,omitempty"`
+}
+
+// Alert models an active alert.
+type Alert struct {
+	ActiveAt    time.Time `json:"activeAt"`
+	Annotations model.LabelSet
+	Labels      model.LabelSet
+	State       AlertState
+	Value       string
+}
+
+// TargetsResult contains the result from querying the targets endpoint.
+type TargetsResult struct {
+	Active  []ActiveTarget  `json:"activeTargets"`
+	Dropped []DroppedTarget `json:"droppedTargets"`
+}
+
+// ActiveTarget models an active Prometheus scrape target.
+type ActiveTarget struct {
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+	Labels           model.LabelSet    `json:"labels"`
+	ScrapeURL        string            `json:"scrapeUrl"`
+	LastError        string            `json:"lastError"`
+	LastScrape       time.Time         `json:"lastScrape"`
+	Health           HealthStatus      `json:"health"`
+}
+
+// DroppedTarget models a dropped Prometheus scrape target.
+type DroppedTarget struct {
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+}
+
+// MetricMetadata models the metadata of a metric with its scrape target and name.
+type MetricMetadata struct {
+	Target map[string]string `json:"target"`
+	Metric string            `json:"metric,omitempty"`
+	Type   MetricType        `json:"type"`
+	Help   string            `json:"help"`
+	Unit   string            `json:"unit"`
+}
+
+// Metadata models the metadata of a metric.
+type Metadata struct {
+	Type MetricType `json:"type"`
+	Help string     `json:"help"`
+	Unit string     `json:"unit"`
+}
+
+// queryResult contains result data for a query.
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	// The decoded value.
+	v model.Value
+}
+
+func (rg *RuleGroup) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Name     string            `json:"name"`
+		File     string            `json:"file"`
+		Interval float64           `json:"interval"`
+		Rules    []json.RawMessage `json:"rules"`
+	}{}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	rg.Name = v.Name
+	rg.File = v.File
+	rg.Interval = v.Interval
+
+	for _, rule := range v.Rules {
+		alertingRule := AlertingRule{}
+		if err := json.Unmarshal(rule, &alertingRule); err == nil {
+			rg.Rules = append(rg.Rules, alertingRule)
+			continue
+		}
+		recordingRule := RecordingRule{}
+		if err := json.Unmarshal(rule, &recordingRule); err == nil {
+			rg.Rules = append(rg.Rules, recordingRule)
+			continue
+		}
+		return errors.New("failed to decode JSON into an alerting or recording rule")
+	}
+
+	return nil
+}
+
+func (r *AlertingRule) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v.Type == "" {
+		return errors.New("type field not present in rule")
+	}
+	if v.Type != string(RuleTypeAlerting) {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeAlerting), v.Type)
+	}
+
+	rule := struct {
+		Name        string         `json:"name"`
+		Query       string         `json:"query"`
+		Duration    float64        `json:"duration"`
+		Labels      model.LabelSet `json:"labels"`
+		Annotations model.LabelSet `json:"annotations"`
+		Alerts      []*Alert       `json:"alerts"`
+		Health      RuleHealth     `json:"health"`
+		LastError   string         `json:"lastError,omitempty"`
+	}{}
+	if err := json.Unmarshal(b, &rule); err != nil {
+		return err
+	}
+	r.Health = rule.Health
+	r.Annotations = rule.Annotations
+	r.Name = rule.Name
+	r.Query = rule.Query
+	r.Alerts = rule.Alerts
+	r.Duration = rule.Duration
+	r.Labels = rule.Labels
+	r.LastError = rule.LastError
+
+	return nil
+}
+
+func (r *RecordingRule) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v.Type == "" {
+		return errors.New("type field not present in rule")
+	}
+	if v.Type != string(RuleTypeRecording) {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeRecording), v.Type)
+	}
+
+	rule := struct {
+		Name      string         `json:"name"`
+		Query     string         `json:"query"`
+		Labels    model.LabelSet `json:"labels,omitempty"`
+		Health    RuleHealth     `json:"health"`
+		LastError string         `json:"lastError,omitempty"`
+	}{}
+	if err := json.Unmarshal(b, &rule); err != nil {
+		return err
+	}
+	r.Health = rule.Health
+	r.Labels = rule.Labels
+	r.Name = rule.Name
+	r.LastError = rule.LastError
+	r.Query = rule.Query
+
+	return nil
+}
+
+func (qr *queryResult) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case model.ValScalar:
+		var sv model.Scalar
+		err = json.Unmarshal(v.Result, &sv)
+		qr.v = &sv
+
+	case model.ValVector:
+		var vv model.Vector
+		err = json.Unmarshal(v.Result, &vv)
+		qr.v = vv
+
+	case model.ValMatrix:
+		var mv model.Matrix
+		err = json.Unmarshal(v.Result, &mv)
+		qr.v = mv
+
+	default:
+		err = fmt.Errorf("unexpected value type %q", v.Type)
+	}
+	return err
+}
+
+// NewAPI returns a new API for the client.
+//
+// It is safe to use the returned API from multiple goroutines.
+func NewAPI(c api.Client) API {
+	return &httpAPI{
+		client: &apiClientImpl{
+			client: c,
+		},
+	}
+}
+
+type httpAPI struct {
+	client apiClient
+}
+
+func (h *httpAPI) Alerts(ctx context.Context) (AlertsResult, error) {
+	u := h.client.URL(epAlerts, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertsResult{}, err
+	}
+
+	var res AlertsResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) AlertManagers(ctx context.Context) (AlertManagersResult, error) {
+	u := h.client.URL(epAlertManagers, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	var res AlertManagersResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) CleanTombstones(ctx context.Context) error {
+	u := h.client.URL(epCleanTombstones, nil)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Config(ctx context.Context) (ConfigResult, error) {
+	u := h.client.URL(epConfig, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	var res ConfigResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+	u := h.client.URL(epDeleteSeries, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	q.Set("start", formatTime(startTime))
+	q.Set("end", formatTime(endTime))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
+	u := h.client.URL(epFlags, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	var res FlagsResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) LabelNames(ctx context.Context) ([]string, Warnings, error) {
+	u := h.client.URL(epLabels, nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, body, w, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, w, err
+	}
+	var labelNames []string
+	return labelNames, w, json.Unmarshal(body, &labelNames)
+}
+
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matchs []string) (model.LabelValues, Warnings, error) {
+	u := h.client.URL(epLabelValues, map[string]string{"name": label})
+	q := u.Query()
+
+	for _, m := range matchs {
+		q.Add("match[]", m)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, body, w, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, w, err
+	}
+	var labelValues model.LabelValues
+	return labelValues, w, json.Unmarshal(body, &labelValues)
+}
+
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, Warnings, error) {
+	u := h.client.URL(epQuery, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	if !ts.IsZero() {
+		q.Set("time", formatTime(ts))
+	}
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+	return model.Value(qres.v), warnings, json.Unmarshal(body, &qres)
+}
+
+func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range) (model.Value, Warnings, error) {
+	u := h.client.URL(epQueryRange, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	q.Set("start", formatTime(r.Start))
+	q.Set("end", formatTime(r.End))
+	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+
+	return model.Value(qres.v), warnings, json.Unmarshal(body, &qres)
+}
+
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, Warnings, error) {
+	u := h.client.URL(epSeries, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	q.Set("start", formatTime(startTime))
+	q.Set("end", formatTime(endTime))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, body, warnings, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var mset []model.LabelSet
+	return mset, warnings, json.Unmarshal(body, &mset)
+}
+
+func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
+	u := h.client.URL(epSnapshot, nil)
+	q := u.Query()
+
+	q.Set("skip_head", strconv.FormatBool(skipHead))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	var res SnapshotResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) Rules(ctx context.Context) (RulesResult, error) {
+	u := h.client.URL(epRules, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return RulesResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return RulesResult{}, err
+	}
+
+	var res RulesResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) Targets(ctx context.Context) (TargetsResult, error) {
+	u := h.client.URL(epTargets, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	var res TargetsResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]MetricMetadata, error) {
+	u := h.client.URL(epTargetsMetadata, nil)
+	q := u.Query()
+
+	q.Set("match_target", matchTarget)
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []MetricMetadata
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) Metadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error) {
+	u := h.client.URL(epMetadata, nil)
+	q := u.Query()
+
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string][]Metadata
+	return res, json.Unmarshal(body, &res)
+}
+
+// Warnings is an array of non critical errors
+type Warnings []string
+
+// apiClient wraps a regular client and processes successful API responses.
+// Successful also includes responses that errored at the API level.
+type apiClient interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
+	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error)
+}
+
+type apiClientImpl struct {
+	client api.Client
+}
+
+type apiResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType ErrorType       `json:"errorType"`
+	Error     string          `json:"error"`
+	Warnings  []string        `json:"warnings,omitempty"`
+}
+
+func apiError(code int) bool {
+	// These are the codes that Prometheus sends when it returns an error.
+	return code == statusAPIError || code == http.StatusBadRequest
+}
+
+func errorTypeAndMsgFor(resp *http.Response) (ErrorType, string) {
+	switch resp.StatusCode / 100 {
+	case 4:
+		return ErrClient, fmt.Sprintf("client error: %d", resp.StatusCode)
+	case 5:
+		return ErrServer, fmt.Sprintf("server error: %d", resp.StatusCode)
+	}
+	return ErrBadResponse, fmt.Sprintf("bad response code %d", resp.StatusCode)
+}
+
+func (h *apiClientImpl) URL(ep string, args map[string]string) *url.URL {
+	return h.client.URL(ep, args)
+}
+
+func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return resp, body, nil, err
+	}
+
+	code := resp.StatusCode
+
+	if code/100 != 2 && !apiError(code) {
+		errorType, errorMsg := errorTypeAndMsgFor(resp)
+		return resp, body, nil, &Error{
+			Type:   errorType,
+			Msg:    errorMsg,
+			Detail: string(body),
+		}
+	}
+
+	var result apiResponse
+
+	if http.StatusNoContent != code {
+		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
+			return resp, body, nil, &Error{
+				Type: ErrBadResponse,
+				Msg:  jsonErr.Error(),
+			}
+		}
+	}
+
+	if apiError(code) != (result.Status == "error") {
+		err = &Error{
+			Type: ErrBadResponse,
+			Msg:  "inconsistent body for response code",
+		}
+	}
+
+	if apiError(code) && result.Status == "error" {
+		err = &Error{
+			Type: result.ErrorType,
+			Msg:  result.Error,
+		}
+	}
+
+	return resp, []byte(result.Data), result.Warnings, err
+
+}
+
+// DoGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
+func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, body, warnings, err := h.Do(ctx, req)
+	if resp != nil && resp.StatusCode == http.StatusMethodNotAllowed {
+		u.RawQuery = args.Encode()
+		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, nil, warnings, err
+		}
+
+	} else {
+		if err != nil {
+			return resp, body, warnings, err
+		}
+		return resp, body, warnings, nil
+	}
+	return h.Do(ctx, req)
+}
+
+func formatTime(t time.Time) string {
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
+}

--- a/src/modules/server/backend/prom/data.go
+++ b/src/modules/server/backend/prom/data.go
@@ -1,0 +1,213 @@
+package prom
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/didi/nightingale/v4/src/common/dataobj"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/toolkits/pkg/logger"
+)
+
+const (
+	GaugeTypeStr = "GAUGE"
+)
+
+type MetricMeta struct {
+	Name     string
+	Endpoind string
+	Nid      string
+	Tags     map[string]string
+}
+
+func (prom *PromDataSource) convert2PromTimeSeries(item *dataobj.MetricValue) (*prompb.TimeSeries, error) {
+	pt := &prompb.TimeSeries{}
+	pt.Samples = append(pt.Samples, prompb.Sample{
+		// 时间赋值问题,使用毫秒时间戳
+		Timestamp: item.Timestamp * 1000,
+		Value:     item.Value,
+	})
+	var labels []*prompb.Label
+
+	name, err := prom.convertN9eMetricName(item.Metric)
+	if err != nil {
+		logger.Errorf("convert n9e metric name: %s got error: %v", item.Metric, err)
+		return pt, err
+	}
+	nameLs := &prompb.Label{
+		Name:  model.MetricNameLabel,
+		Value: name,
+	}
+	labels = append(labels, nameLs)
+
+	if item.Endpoint != "" {
+		identLs := &prompb.Label{
+			Name:  LabelEndpoint,
+			Value: item.Endpoint,
+		}
+		labels = append(labels, identLs)
+	}
+
+	if item.Nid != "" {
+		nodeLs := &prompb.Label{
+			Name:  LabelNid,
+			Value: item.Nid,
+		}
+		labels = append(labels, nodeLs)
+	}
+
+	for k, v := range item.TagsMap {
+		lname, err := convertN9eLabelName(k)
+		if err != nil {
+			logger.Errorf("conver tag name: %s got error: %+v", k, err)
+			return pt, err
+		}
+		ls := &prompb.Label{
+			Name:  lname,
+			Value: v,
+		}
+		labels = append(labels, ls)
+	}
+
+	pt.Labels = append(pt.Labels, labels...)
+	return pt, nil
+}
+
+func convertValuesToRRDResp(value model.Value) []*dataobj.TsdbQueryResponse {
+	switch value.Type() {
+	case model.ValMatrix:
+		v, ok := value.(model.Matrix)
+		if !ok {
+			return nil
+		}
+		return convertMatrixValuesToRRDResp(v)
+	case model.ValVector:
+		v, ok := value.(model.Vector)
+		if !ok {
+			return nil
+		}
+		return convertVectorValuesToRRDResp(v)
+	case model.ValNone:
+		fallthrough
+	case model.ValString:
+		fallthrough
+	case model.ValScalar:
+		fallthrough
+	default:
+		return nil
+	}
+}
+
+func convertVectorValuesToRRDResp(value model.Vector) []*dataobj.TsdbQueryResponse {
+	rmap := make(map[string]*dataobj.TsdbQueryResponse)
+	for _, v := range value {
+		data := dataobj.RRDData{
+			Timestamp: v.Timestamp.Unix(),
+			Value:     dataobj.JsonFloat(v.Value),
+		}
+		_, ok := v.Metric[model.MetricNameLabel]
+		if !ok {
+			continue
+		}
+
+		key := v.Metric.String()
+		rdata, ok := rmap[key]
+		if ok {
+			rdata.Values = append(rdata.Values, &data)
+			continue
+		}
+
+		rdata = &dataobj.TsdbQueryResponse{
+			Values: []*dataobj.RRDData{&data},
+		}
+		rmap[key] = rdata
+
+		meta := getMetricInfos(v.Metric)
+		rdata.Endpoint = meta.Endpoind
+		rdata.Nid = meta.Nid
+
+		var tags []string
+		for k, v := range meta.Tags {
+			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+		}
+
+		rdata.Counter = fmt.Sprintf("%s/%s", meta.Name, strings.Join(tags, ","))
+		rdata.DsType = GaugeTypeStr
+	}
+
+	var ret []*dataobj.TsdbQueryResponse
+	for _, res := range rmap {
+		ret = append(ret, res)
+	}
+	return ret
+}
+
+func convertMatrixValuesToRRDResp(value model.Matrix) []*dataobj.TsdbQueryResponse {
+	rmap := make(map[string]*dataobj.TsdbQueryResponse)
+	for _, v := range value {
+		var dataList []*dataobj.RRDData
+		for _, vv := range v.Values {
+			dataList = append(dataList, &dataobj.RRDData{
+				Timestamp: vv.Timestamp.Unix(),
+				Value:     dataobj.JsonFloat(vv.Value),
+			})
+		}
+		_, ok := v.Metric[model.MetricNameLabel]
+		if !ok {
+			continue
+		}
+
+		key := v.Metric.String()
+		rdata, ok := rmap[key]
+		if ok {
+			rdata.Values = append(rdata.Values, dataList...)
+			continue
+		}
+
+		rdata = &dataobj.TsdbQueryResponse{
+			Values: dataList,
+		}
+		rmap[key] = rdata
+
+		// var tagMap map[string]string
+		meta := getMetricInfos(v.Metric)
+		rdata.Endpoint = meta.Endpoind
+		rdata.Nid = meta.Nid
+
+		var tags []string
+		for k, v := range meta.Tags {
+			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+		}
+
+		rdata.Counter = fmt.Sprintf("%s/%s", meta.Name, strings.Join(tags, ","))
+		rdata.DsType = GaugeTypeStr
+	}
+
+	var ret []*dataobj.TsdbQueryResponse
+	for _, res := range rmap {
+		ret = append(ret, res)
+	}
+	return ret
+}
+
+func getMetricInfos(m model.Metric) MetricMeta {
+	meta := MetricMeta{
+		Tags: make(map[string]string),
+	}
+	for k, v := range m {
+		if string(k) == model.MetricNameLabel {
+			meta.Name = string(v)
+			continue
+		}
+		if string(k) == LabelEndpoint {
+			meta.Endpoind = string(v)
+			continue
+		}
+		if string(k) == LabelNid {
+			meta.Nid = string(v)
+		}
+		meta.Tags[string(k)] = string(v)
+	}
+	return meta
+}

--- a/src/modules/server/backend/prom/metric.go
+++ b/src/modules/server/backend/prom/metric.go
@@ -1,0 +1,193 @@
+package prom
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/toolkits/pkg/logger"
+)
+
+const (
+	LabelEndpoint = "endpoint"
+	LabelNid      = "rdb_node_id"
+)
+
+type metricSelector map[string]metricSelectorValues
+type metricSelectorValues []string
+
+func (prom *PromDataSource) newMetricSelector(metrics, endpoints, nids []string) (selector metricSelector) {
+	selector = make(map[string]metricSelectorValues)
+
+	var names []string
+	if metrics != nil && len(metrics) > 0 {
+		for _, m := range metrics {
+			name, err := prom.convertN9eMetricName(m)
+			if err != nil {
+				logger.Errorf("metric convert error: %v", err)
+				continue
+			}
+			names = append(names, name)
+		}
+	}
+
+	selector.addLabels(model.MetricNameLabel, names)
+	selector.addLabels(LabelEndpoint, endpoints)
+	selector.addLabels(LabelNid, nids)
+
+	return selector
+}
+
+func (prom *PromDataSource) newSelectorByMeta(metric MetricMeta) (selector metricSelector) {
+	selector = make(map[string]metricSelectorValues, len(metric.Tags)+3)
+	selector.addMetricMeta(metric)
+
+	return selector
+}
+
+func (selector *metricSelector) clear() {
+	*selector = make(metricSelector)
+}
+
+func (selector metricSelector) addLabel(name string, value string) {
+	if len(name) <= 0 || len(value) <= 0 {
+		return
+	}
+	name, err := convertN9eLabelName(name)
+	if err != nil {
+		logger.Errorf("convert n9e tag name: %s got error: %v", name, err)
+		return
+	}
+
+	selector[name] = append(selector[name], value)
+}
+
+func (selector metricSelector) addLabels(name string, values []string) {
+	if len(name) <= 0 || values == nil || len(values) <= 0 {
+		return
+	}
+	name, err := convertN9eLabelName(name)
+	if err != nil {
+		logger.Errorf("convert n9e tag name: %s got error: %v", name, err)
+		return
+	}
+
+	selector[name] = append(selector[name], values...)
+}
+
+func (selector metricSelector) addLabelList(list []string) {
+	for _, l := range list {
+		pair := strings.SplitN(l, "=", 2)
+		if len(pair) != 2 {
+			continue
+		}
+
+		selector.addLabel(pair[0], pair[1])
+	}
+}
+
+func (selector metricSelector) addMetricMeta(metric MetricMeta) {
+	if len(metric.Name) > 0 {
+		selector.addLabel(model.MetricNameLabel, metric.Name)
+	}
+	if len(metric.Endpoind) > 0 {
+		selector.addLabel(LabelEndpoint, metric.Endpoind)
+	}
+	if len(metric.Nid) > 0 {
+		selector.addLabel(LabelNid, metric.Nid)
+	}
+
+	for k, v := range metric.Tags {
+		if len(v) > 0 {
+			selector.addLabel(k, v)
+		}
+	}
+}
+
+func (selector metricSelector) String() string {
+	var pairs []string
+	for name, values := range selector {
+		pairs = append(pairs, fmt.Sprintf("%s=~\"%s\"", name, values))
+	}
+
+	return fmt.Sprintf("{%s}", strings.Join(pairs, ","))
+}
+
+func (values *metricSelectorValues) dedup() metricSelectorValues {
+	vm := make(map[string]struct{})
+	for _, v := range *values {
+		if len(v) > 0 {
+			vm[v] = struct{}{}
+		}
+	}
+
+	var nv metricSelectorValues
+	for v := range vm {
+		nv = append(nv, v)
+	}
+
+	*values = nv
+	return nv
+}
+
+func (values metricSelectorValues) String() string {
+	values.dedup()
+
+	return strings.Join(values, "|")
+}
+
+type replacePair struct {
+	n9e  string
+	prom string
+}
+
+var (
+	ErrInvalidName   = errors.New("invalid name")
+	ErrWrongResponse = errors.New("http request got error")
+
+	replaceList = []replacePair{
+		{n9e: ".", prom: "__dot__"},
+		{n9e: "-", prom: "__sub__"},
+	}
+)
+
+func (prom *PromDataSource) convertN9eMetricName(name string) (string, error) {
+	new := prom.Section.Prefix + convertN9eName(name)
+	if !model.MetricNameRE.MatchString(new) {
+		return new, fmt.Errorf("metric name: %s get: %w", name, ErrInvalidName)
+	}
+	return new, nil
+}
+
+func (prom *PromDataSource) convertPromMetricName(name string) string {
+	if !strings.HasPrefix(name, prom.Section.Prefix) {
+		return ""
+	}
+	name = strings.Replace(name, prom.Section.Prefix, "", 1)
+	return convertPromName(name)
+}
+
+func convertN9eLabelName(name string) (string, error) {
+	new := convertN9eName(name)
+	if !model.LabelNameRE.MatchString(new) {
+		return new, fmt.Errorf("label name: %s get: %w", name, ErrInvalidName)
+	}
+	return new, nil
+}
+
+func convertN9eName(name string) string {
+	for _, pair := range replaceList {
+		name = strings.ReplaceAll(name, pair.n9e, pair.prom)
+	}
+
+	return name
+}
+
+func convertPromName(name string) string {
+	for _, pair := range replaceList {
+		name = strings.ReplaceAll(name, pair.prom, pair.n9e)
+	}
+
+	return name
+}

--- a/src/modules/server/backend/prom/prom.go
+++ b/src/modules/server/backend/prom/prom.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Xiaomi, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prom
+
+import (
+	"time"
+
+	"github.com/didi/nightingale/v4/src/common/dataobj"
+	"github.com/didi/nightingale/v4/src/common/stats"
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+
+	"github.com/toolkits/pkg/container/list"
+	"github.com/toolkits/pkg/logger"
+)
+
+type PromSection struct {
+	Enabled bool   `yaml:"enabled"`
+	Name    string `yaml:"name"`
+	Batch   int    `yaml:"batch"`
+	Prefix  string `yaml:"prefix"`
+
+	RemoteRead  []PromClientConfig `yaml:"remoteRead"`
+	RemoteWrite []PromClientConfig `yaml:"remoteWrite"`
+}
+
+type PromDataSource struct {
+	//config
+	Section               PromSection
+	SendQueueMaxSize      int
+	SendTaskSleepInterval time.Duration
+
+	// 发送缓存队列 node -> queue_of_data
+	PushQueue *list.SafeListLimited
+
+	// prometheus clients
+	ReadClients  PromReadClientList
+	WriteClients PromWriteClientList
+}
+
+type PromClientConfig struct {
+	URL           config_util.URL `mapstructure:"none",yaml:"url"`
+	RemoteTimeout model.Duration  `yaml:"remote_timeout,omitempty"`
+	Name          string          `yaml:"name,omitempty"`
+}
+
+func (prom *PromDataSource) Init() {
+
+	// init push queues
+	prom.PushQueue = list.NewSafeListLimited(prom.SendQueueMaxSize)
+
+	prom.InitWriteClient()
+	prom.InitReadClient()
+
+	go prom.Send2PromTask()
+
+}
+
+// Push2Queue pushes data to prometheus remote write
+func (prom *PromDataSource) Push2Queue(items []*dataobj.MetricValue) {
+	errCnt := 0
+	for _, item := range items {
+		_ = item
+		promItem, err := prom.convert2PromTimeSeries(item)
+		if err != nil {
+			errCnt++
+			logger.Warningf("convert metric: %v to prom got error: %v", item, err)
+			continue
+		}
+		stats.Counter.Set("prom.queue.push", 1)
+
+		if !prom.PushQueue.PushFront(promItem) {
+			errCnt++
+			logger.Warningf("convert metric: %v to prom got error: %v", item, err)
+			continue
+		}
+	}
+
+	// statistics
+	if errCnt > 0 {
+		stats.Counter.Set("prom.queue.err", errCnt)
+		logger.Warning("Push2PromSendQueue err num: ", errCnt)
+	}
+}
+
+func (prom *PromDataSource) Send2PromTask() {
+	batch := prom.Section.Batch // 一次发送,最多batch条数据
+	if batch <= 0 {
+		batch = 10000
+	}
+
+	for {
+		items := prom.PushQueue.PopBackBy(batch)
+		count := len(items)
+		if count == 0 {
+			time.Sleep(prom.SendTaskSleepInterval)
+			continue
+		}
+
+		stats.Counter.Set("points.out.prom", count)
+
+		errCnt := prom.WriteClients.RemoteWriteToList(items)
+		stats.Counter.Set("points.out.prom.error", errCnt)
+	}
+}
+
+func (prom *PromDataSource) GetInstance(metric, endpoint string, tags map[string]string) []string {
+	var ret []string
+	for _, conf := range prom.Section.RemoteRead {
+		ret = append(ret, conf.URL.String())
+	}
+	return ret
+}

--- a/src/modules/server/backend/prom/query.go
+++ b/src/modules/server/backend/prom/query.go
@@ -1,0 +1,288 @@
+// Copyright 2017 Xiaomi, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prom
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/didi/nightingale/v4/src/common/dataobj"
+	"github.com/prometheus/common/model"
+
+	"github.com/toolkits/pkg/concurrent/semaphore"
+)
+
+func (prom *PromDataSource) QueryData(inputs []dataobj.QueryData) []*dataobj.TsdbQueryResponse {
+	var resp []*dataobj.TsdbQueryResponse
+
+	sema := semaphore.NewSemaphore(20)
+	wg := &sync.WaitGroup{}
+	lock := &sync.Mutex{}
+
+	for _, input := range inputs {
+		for _, counter := range input.Counters {
+			wg.Add(1)
+			sema.Acquire()
+			go func(q dataobj.QueryData, c string) {
+				defer wg.Done()
+				defer sema.Release()
+
+				metric, tags := decodeCounter(c)
+				if metric == nil {
+					return
+				}
+
+				selector := prom.newMetricSelector([]string{*metric}, q.Endpoints, q.Nids)
+				selector.addLabelList(tags)
+
+				value, err := prom.ReadClients.QueryRange(selector, q.Start, q.End, q.Step)
+				if err != nil {
+					return
+				}
+
+				for idx := range value {
+					value[idx].Counter = prom.convertPromMetricName(value[idx].Counter)
+				}
+
+				lock.Lock()
+				defer lock.Unlock()
+				resp = append(resp, value...)
+			}(input, counter)
+
+		}
+	}
+
+	wg.Wait()
+	return resp
+}
+
+func (prom *PromDataSource) QueryDataForUI(input dataobj.QueryDataForUI) []*dataobj.TsdbQueryResponse {
+	selector := prom.newMetricSelector([]string{input.Metric}, input.Endpoints, input.Nids)
+	selector.addLabelList(input.Tags)
+
+	value, err := prom.ReadClients.QueryRange(selector, input.Start, input.End, input.Step)
+	if err != nil {
+		return nil
+	}
+
+	for idx := range value {
+		value[idx].Counter = prom.convertPromMetricName(value[idx].Counter)
+	}
+	return value
+}
+
+func (prom *PromDataSource) QueryMetrics(recv dataobj.EndpointsRecv) *dataobj.MetricResp {
+	selector := prom.newMetricSelector(nil, recv.Endpoints, recv.Nids)
+
+	labels, err := prom.ReadClients.LabelValues(model.MetricNameLabel, []metricSelector{selector})
+	if err != nil {
+		return nil
+	}
+	if labels == nil || len(labels) <= 0 {
+		return nil
+	}
+
+	var metrics []string
+	for _, l := range labels {
+		if !strings.HasPrefix(l, prom.Section.Prefix) {
+			continue
+		}
+		metrics = append(metrics, prom.convertPromMetricName(l))
+	}
+
+	return &dataobj.MetricResp{
+		Metrics: metrics,
+	}
+}
+
+func (prom *PromDataSource) QueryTagPairs(recv dataobj.EndpointMetricRecv) []dataobj.IndexTagkvResp {
+	if len(recv.Metrics) <= 0 {
+		return nil
+	}
+	if len(recv.Endpoints) <= 0 && len(recv.Nids) <= 0 {
+		return nil
+	}
+
+	selector := prom.newMetricSelector(recv.Metrics, recv.Endpoints, recv.Nids)
+	end := time.Now()
+	start := end.AddDate(0, 0, -3)
+
+	metrics, err := prom.ReadClients.GetSeries([]metricSelector{selector}, start.Unix(), end.Unix())
+	if err != nil {
+		return nil
+	}
+	if metrics == nil || len(metrics) <= 0 {
+		return nil
+	}
+
+	smap := make(map[string]metricSelector)
+	for _, metric := range metrics {
+		if len(metric.Name) <= 0 {
+			continue
+		}
+		name := prom.convertPromMetricName(metric.Name)
+		if len(name) <= 0 {
+			continue
+		}
+
+		s, ok := smap[name]
+		if !ok {
+			smap[name] = prom.newSelectorByMeta(metric)
+			continue
+		}
+
+		s.addMetricMeta(metric)
+	}
+
+	var ret []dataobj.IndexTagkvResp
+	for name, selector := range smap {
+		tagkv := dataobj.IndexTagkvResp{
+			Metric: name,
+		}
+		for lnane, lval := range selector {
+			if lval == nil || len(lval) <= 0 {
+				continue
+			}
+
+			if lnane == model.MetricNameLabel {
+				continue
+			}
+			if lnane == LabelEndpoint {
+				tagkv.Endpoints = lval.dedup()
+				continue
+			}
+			if lnane == LabelNid {
+				tagkv.Nids = lval.dedup()
+				continue
+			}
+
+			pair := &dataobj.TagPair{
+				Key:    lnane,
+				Values: lval.dedup(),
+			}
+			tagkv.Tagkv = append(tagkv.Tagkv, pair)
+		}
+		ret = append(ret, tagkv)
+	}
+
+	return ret
+}
+
+func (prom *PromDataSource) QueryIndexByClude(recv []dataobj.CludeRecv) []dataobj.XcludeResp {
+	return nil
+}
+
+func (prom *PromDataSource) QueryIndexByFullTags(recv []dataobj.IndexByFullTagsRecv) ([]dataobj.IndexByFullTagsResp, int) {
+	count := 0
+	var ret []dataobj.IndexByFullTagsResp
+
+	for _, r := range recv {
+		res := prom.QueryIndexByFullTagsOne(r)
+		if res != nil {
+			ret = append(ret, *res)
+			count += res.Count
+		}
+	}
+	return ret, count
+}
+
+func (prom *PromDataSource) QueryIndexByFullTagsOne(recv dataobj.IndexByFullTagsRecv) *dataobj.IndexByFullTagsResp {
+	if len(recv.Metric) <= 0 {
+		return nil
+	}
+	if len(recv.Endpoints) <= 0 && len(recv.Nids) <= 0 {
+		return nil
+	}
+
+	selector := prom.newMetricSelector([]string{recv.Metric}, recv.Endpoints, recv.Nids)
+	for _, tagkv := range recv.Tagkv {
+		selector.addLabels(tagkv.Key, tagkv.Values)
+	}
+
+	metrics, err := prom.ReadClients.GetSeries([]metricSelector{selector}, recv.Start, recv.End)
+	if err != nil {
+		return nil
+	}
+	if metrics == nil || len(metrics) <= 0 {
+		return nil
+	}
+
+	resp := dataobj.IndexByFullTagsResp{
+		Metric: recv.Metric,
+		Step:   30,
+		DsType: GaugeTypeStr,
+		Count:  0,
+	}
+
+	endpointMap := make(map[string]struct{})
+	nidMap := make(map[string]struct{})
+	tagsMap := make(map[string]struct{})
+	for _, metric := range metrics {
+		name := prom.convertPromMetricName(metric.Name)
+		if name != recv.Metric {
+			continue
+		}
+
+		resp.Count++
+		if len(metric.Endpoind) > 0 {
+			endpointMap[metric.Endpoind] = struct{}{}
+		}
+		if len(metric.Nid) > 0 {
+			endpointMap[metric.Nid] = struct{}{}
+		}
+
+		for k, v := range metric.Tags {
+			// TODO: trick need remove
+			if strings.HasPrefix(k, prom.Section.Prefix) {
+				continue
+			}
+			tag := fmt.Sprintf("%s=%s", k, v)
+			tagsMap[tag] = struct{}{}
+		}
+	}
+
+	for e := range endpointMap {
+		resp.Endpoints = append(resp.Endpoints, e)
+	}
+	for n := range nidMap {
+		resp.Nids = append(resp.Nids, n)
+	}
+	for t := range tagsMap {
+		resp.Tags = append(resp.Tags, t)
+	}
+
+	return &resp
+}
+
+func decodeCounter(counter string) (*string, []string) {
+	mt := strings.SplitN(counter, "/", 2)
+	lenmt := len(mt)
+
+	var metric string
+	if lenmt <= 0 {
+		return nil, nil
+	}
+	if lenmt == 1 {
+		metric = mt[0]
+		return &metric, nil
+	}
+	metric = mt[0]
+
+	tagList := strings.Split(mt[1], ",")
+
+	return &metric, tagList
+}

--- a/src/modules/server/backend/prom/read_client.go
+++ b/src/modules/server/backend/prom/read_client.go
@@ -1,0 +1,200 @@
+package prom
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/didi/nightingale/v4/src/common/dataobj"
+	promapi "github.com/prometheus/client_golang/api"
+
+	"github.com/prometheus/common/model"
+	"github.com/toolkits/pkg/logger"
+)
+
+type PromReadClientList []*PromReadClient
+
+type PromReadClient struct {
+	conf   PromClientConfig
+	client API
+}
+
+func (prom *PromDataSource) InitReadClient() error {
+	conf := prom.Section.RemoteRead
+	clients := make([]*PromReadClient, 0, len(conf))
+	for _, wc := range conf {
+
+		c, err := newReadClient(wc)
+		if err != nil {
+			logger.Errorf("init new write client got error: %s, config: %+v", err.Error(), wc)
+			return err
+		}
+
+		clients = append(clients, c)
+	}
+
+	prom.ReadClients = clients
+	return nil
+}
+
+func newReadClient(conf PromClientConfig) (*PromReadClient, error) {
+	name := conf.Name
+	if name == "" {
+		hash, err := toHash(conf)
+		if err != nil {
+			return nil, err
+		}
+
+		name = hash[:6]
+	}
+
+	c, err := promapi.NewClient(promapi.Config{
+		Address: conf.URL.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &PromReadClient{
+		conf:   conf,
+		client: NewAPI(c),
+	}, nil
+}
+
+func (list PromReadClientList) LabelValues(lname string, matchs []metricSelector) ([]string, error) {
+	var matchStrs []string
+	for _, m := range matchs {
+		matchStrs = append(matchStrs, m.String())
+	}
+
+	var vals model.LabelValues
+	var err error
+	for _, idx := range rand.Perm(len(list)) {
+		vals, err = list[idx].LabelValues(lname, matchStrs)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []string
+	for _, val := range vals {
+		ret = append(ret, string(val))
+	}
+	return ret, nil
+}
+
+func (list PromReadClientList) GetSeries(matchs []metricSelector, start, end int64) ([]MetricMeta, error) {
+	var matchStrs []string
+	for _, m := range matchs {
+		matchStrs = append(matchStrs, m.String())
+	}
+	var startTime, endTime time.Time
+	if end <= 0 {
+		endTime = time.Now()
+	} else {
+		endTime = time.Unix(end, 0)
+	}
+	if start <= 0 || start >= end {
+		startTime = endTime.AddDate(0, 0, -3)
+	} else {
+		startTime = time.Unix(start, 0)
+	}
+
+	var labels []model.LabelSet
+	var err error
+	for _, idx := range rand.Perm(len(list)) {
+		labels, err = list[idx].GetSeries(matchStrs, startTime, endTime)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var metrics []MetricMeta
+	for _, lset := range labels {
+		metrics = append(metrics, getMetricInfos(model.Metric(lset)))
+	}
+	return metrics, nil
+}
+
+func (list PromReadClientList) QueryRange(metric metricSelector, start, end int64, step int) ([]*dataobj.TsdbQueryResponse, error) {
+	metricStr := metric.String()
+	startTime := time.Unix(start, 0)
+	endTime := time.Unix(end, 0)
+	stepDur := time.Second * time.Duration(step)
+
+	r := Range{
+		Start: startTime,
+		End:   endTime,
+		Step:  stepDur,
+	}
+	r.Validate()
+
+	var val model.Value
+	var err error
+	for _, idx := range rand.Perm(len(list)) {
+		val, err = list[idx].QueryRange(metricStr, r)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp := convertValuesToRRDResp(val)
+
+	for i := range resp {
+		resp[i].Start = start
+		resp[i].End = end
+		resp[i].Step = step
+	}
+
+	return resp, err
+}
+
+func (c *PromReadClient) LabelValues(lname string, matchs []string) (model.LabelValues, error) {
+	vals, warn, err := c.client.LabelValues(context.Background(), lname, matchs)
+	if err != nil {
+		logger.Errorf("query label values got error: %s, client: %s, label name: %s", err, c.conf.Name, lname)
+		return nil, err
+	}
+	if len(warn) > 0 {
+		logger.Warningf("get metrics name got warnings: %+v, client: %s, label name: %s", warn, c.conf.Name, lname)
+	}
+
+	return vals, nil
+}
+
+func (c *PromReadClient) GetSeries(matchs []string, start, end time.Time) ([]model.LabelSet, error) {
+	labels, warn, err := c.client.Series(context.Background(), matchs, start, end)
+	if err != nil {
+		logger.Errorf("query series got error: %s, client: %s, matchs: %+v", err, c.conf.Name, matchs)
+		return nil, err
+	}
+	if len(warn) > 0 {
+		logger.Warningf("query series got warnings: %+v, client: %s, matchs: %+v", warn, c.conf.Name, matchs)
+	}
+
+	return labels, nil
+}
+
+func (c *PromReadClient) QueryRange(metric string, r Range) (model.Value, error) {
+	values, warn, err := c.client.QueryRange(context.Background(), metric, r)
+	if err != nil {
+		logger.Warningf("query metrics range data got error: %s, client: %s, metric: %+s", err, c.conf.Name, metric)
+		return nil, err
+	}
+	if len(warn) > 0 {
+		logger.Warningf("query metrics range data got warnings: %+v, client: %s, metric: %s", warn, c.conf.Name, metric)
+	}
+	return values, nil
+}

--- a/src/modules/server/backend/prom/write_client.go
+++ b/src/modules/server/backend/prom/write_client.go
@@ -1,0 +1,139 @@
+package prom
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/snappy"
+	promapi "github.com/prometheus/client_golang/api"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/toolkits/pkg/logger"
+	"gopkg.in/yaml.v2"
+)
+
+type PromWriteClientList []*PromWriteClient
+
+type PromWriteClient struct {
+	conf   PromClientConfig
+	client promapi.Client
+}
+
+func (prom *PromDataSource) InitWriteClient() error {
+	conf := prom.Section.RemoteWrite
+	clients := make([]*PromWriteClient, 0, len(conf))
+	for _, wc := range conf {
+
+		c, err := newWriteClient(wc)
+		if err != nil {
+			logger.Errorf("init new write client got error: %s, config: %+v", err.Error(), wc)
+			return err
+		}
+
+		clients = append(clients, c)
+	}
+
+	prom.WriteClients = clients
+	return nil
+}
+
+func newWriteClient(conf PromClientConfig) (*PromWriteClient, error) {
+	name := conf.Name
+	if name == "" {
+		hash, err := toHash(conf)
+		if err != nil {
+			return nil, err
+		}
+
+		name = hash[:6]
+	}
+
+	c, err := promapi.NewClient(promapi.Config{
+		Address: conf.URL.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &PromWriteClient{
+		conf:   conf,
+		client: c,
+	}, nil
+}
+
+func (list PromWriteClientList) RemoteWriteToList(data []interface{}) int {
+	errCnt := 0
+
+	var items []*prompb.TimeSeries
+	for _, dataItem := range data {
+		item, ok := dataItem.(*prompb.TimeSeries)
+		if !ok {
+			errCnt++
+			logger.Warningf("push data to prom but can't convert. data: %+v", dataItem)
+			continue
+		}
+		items = append(items, item)
+	}
+
+	logger.Debugf("push data to prom: %+v", items)
+	for _, client := range list {
+		go client.RemoteWrite(items)
+	}
+
+	return errCnt
+}
+
+func (c *PromWriteClient) RemoteWrite(items []*prompb.TimeSeries) error {
+	req := &prompb.WriteRequest{
+		Timeseries: items,
+	}
+
+	data, err := proto.Marshal(req)
+	if err != nil {
+		logger.Warningf("marshal prom data to proto got error: %s, data: %+v", err.Error(), req)
+		return err
+	}
+
+	bs := snappy.Encode(nil, data)
+
+	return c.Push(bs)
+}
+
+func (c *PromWriteClient) Push(req []byte) error {
+	httpReq, err := http.NewRequest("POST", c.conf.URL.String(), bytes.NewReader(req))
+	if err != nil {
+		logger.Warningf("create remote write request got error: %s", err.Error())
+		return err
+	}
+
+	httpReq.Header.Add("Content-Encoding", "snappy")
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("User-Agent", "n9e")
+	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+
+	resp, body, err := c.client.Do(context.Background(), httpReq)
+	if err != nil {
+		logger.Warningf("push data with remote write request got error: %s, response body: %s", err.Error(), body)
+		return err
+	}
+
+	if resp.StatusCode >= 400 {
+		logger.Warningf("push data with remote write request bad response: %s %s", resp.Status, body)
+		return fmt.Errorf("remote write got HTTP status: %d error: %w", resp.StatusCode, ErrWrongResponse)
+	}
+
+	return nil
+}
+
+func toHash(data interface{}) (string, error) {
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(bytes)
+	return hex.EncodeToString(hash[:]), nil
+}

--- a/src/modules/server/config/config.go
+++ b/src/modules/server/config/config.go
@@ -310,6 +310,13 @@ func Parse(ymlFile string) error {
 		"callTimeout": 3000, //访问超时时间，单位毫秒
 	})
 
+	viper.SetDefault("transfer.backend.prom", map[string]interface{}{
+		"enabled": false,
+		"name":    "prom",
+		"batch":   20000,
+		"prefix":  "n9e_metric_",
+	})
+
 	viper.SetDefault("monapi.proxy", map[string]string{
 		"transfer": "http://127.0.0.1:7900",
 		"index":    "http://127.0.0.1:7904",
@@ -395,6 +402,17 @@ func Parse(ymlFile string) error {
 		}
 
 		Config.Transfer.Backend.M3db = b.Transfer.Backend.M3db
+	}
+
+	if Config.Transfer.Backend.Prom.Enabled {
+		// viper.Unmarshal not compatible with yaml.Unmarshal
+		var b *ConfigT
+		err := yaml.Unmarshal([]byte(bs), &b)
+		if err != nil {
+			return err
+		}
+		Config.Transfer.Backend.Prom.RemoteRead = b.Transfer.Backend.Prom.RemoteRead
+		Config.Transfer.Backend.Prom.RemoteWrite = b.Transfer.Backend.Prom.RemoteWrite
 	}
 
 	fmt.Println("config.file:", ymlFile)

--- a/src/modules/server/server.go
+++ b/src/modules/server/server.go
@@ -78,6 +78,7 @@ func main() {
 	conf := config.Config
 
 	loggeri.Init(conf.Logger)
+	defer logger.GetLogger().Close()
 	i18n.Init()
 	pcache.InitMemoryCache(time.Hour)
 


### PR DESCRIPTION
1. 使用 remote write 接口写入,使用 prometheus http client 读取,支持 VictoriaMetric
2. 主程序入口添加 defer logger close, 保证缓冲区的日志不会丢失
3. 写入的指标带有默认前缀 [ n9e_metric_ ]
4. 特殊字符会被替换 [ . - / ]
5. 标签定义: 主机标签 endpoint. 节点标签 rdb_node_id
