### PR TITLE
修复v4版本不可以发邮件告警的问题

### DIFF
--- a/src/modules/server/notify/notify.go
+++ b/src/modules/server/notify/notify.go
@@ -411,13 +411,14 @@ func send(tos []string, content, subject, notifyType string) error {
 		return fmt.Errorf("tos is empty")
 	}
 
+	message.Tos = tos
 	message.Content = strings.TrimSpace(content)
 	if message.Content == "" {
 		return fmt.Errorf("content is blank")
 	}
 
 	if notifyType == "email" {
-		message.Subject = strings.TrimSpace(message.Subject)
+		message.Subject = strings.TrimSpace(subject)
 		if message.Subject == "" {
 			return fmt.Errorf("subject is blank")
 		}


### PR DESCRIPTION
BUG PR

主要解决v4版本由于message的tos和subject丢失导致无法正常发送邮件