### PR TITLE
修复v5版本按ident标签过滤无法告警问题

### DIFF
--- a/trans/sender.go
+++ b/trans/sender.go
@@ -32,7 +32,9 @@ func send2LocalJudge(q *list.SafeListLimited) {
 
 		points := make([]*vos.MetricPoint, count)
 		for i := 0; i < count; i++ {
-			points[i] = items[i].(*vos.MetricPoint)
+			item := items[i].(*vos.MetricPoint)
+			item.TagsMap["ident"] = item.Ident
+			points[i] = item
 		}
 
 		judge.Send(points)


### PR DESCRIPTION
push的数据默认不带ident tag，如果配置了按ident过滤则告警策略无法匹配。

复现地址：http://116.85.46.86/strategy/edit/17

解决方法：TagsMap带上ident标签。不知道放在此处是否合适。