### PR TITLE
兼容使用pg数据库，contacts字段json格式无法转换的问题

### DIFF
--- a/src/pkg/ormx/types.go
+++ b/src/pkg/ormx/types.go
@@ -12,9 +12,16 @@ type JSONArr json.RawMessage
 
 // 实现 sql.Scanner 接口，Scan 将 value 扫描至 Jsonb
 func (j *JSONObj) Scan(value interface{}) error {
+	// 判断是不是byte类型
 	bytes, ok := value.([]byte)
 	if !ok {
-		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	   // 判断是不是string类型
+	   strings, ok := value.(string)
+	   if !ok {
+	      return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	   }
+	   // string类型转byte[]
+	   bytes = []byte(strings)
 	}
 
 	result := json.RawMessage{}


### PR DESCRIPTION
**What type of PR is this?**
使用pg数据库进行数据存储，pg会认为user表的contacts字段是string类型而json格式无法转换的问题
**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->
夜莺目前支持mysql和postgres，如果DBType使用postgres，用户管理和团队管理模块将无法正常使用

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
![1644917023(1)](https://user-images.githubusercontent.com/38377736/154032048-7d9a88d7-1b23-4a87-87b8-d71ca88cd5d0.png)



**Special notes for your reviewer**:
support postgres databse