### PR TITLE
src/server/router: fix clobbered errors

### DIFF
--- a/src/server/router/router_openfalcon.go
+++ b/src/server/router/router_openfalcon.go
@@ -142,9 +142,10 @@ func (m *FalconMetric) ToProm() (*prompb.TimeSeries, string, error) {
 func falconPush(c *gin.Context) {
 	var bs []byte
 	var err error
+	var r *gzip.Reader
 
 	if c.GetHeader("Content-Encoding") == "gzip" {
-		r, err := gzip.NewReader(c.Request.Body)
+		r, err = gzip.NewReader(c.Request.Body)
 		if err != nil {
 			c.String(400, err.Error())
 			return

--- a/src/server/router/router_opentsdb.go
+++ b/src/server/router/router_opentsdb.go
@@ -125,9 +125,10 @@ func (m *HTTPMetric) ToProm() (*prompb.TimeSeries, error) {
 func handleOpenTSDB(c *gin.Context) {
 	var bs []byte
 	var err error
+	var r *gzip.Reader
 
 	if c.GetHeader("Content-Encoding") == "gzip" {
-		r, err := gzip.NewReader(c.Request.Body)
+		r, err = gzip.NewReader(c.Request.Body)
 		if err != nil {
 			c.String(400, err.Error())
 			return


### PR DESCRIPTION
Two `err` variables in `src/server/router` were being lost because they were being reinitialized inside an if-block with a `:=`.