### PR TITLE
perf(opentsdb): 数据拉取以ident分发，并把list方式改为chan方式，提高消费效率。

### DIFF
--- a/src/server/router/router_opentsdb.go
+++ b/src/server/router/router_opentsdb.go
@@ -164,7 +164,6 @@ func handleOpenTSDB(c *gin.Context) {
 		succ int
 		fail int
 		msg  = "data pushed to queue"
-		list = make([]interface{}, 0, len(arr))
 		ts   = time.Now().Unix()
 		ids  = make(map[string]interface{})
 	)
@@ -191,17 +190,19 @@ func handleOpenTSDB(c *gin.Context) {
 			if has {
 				common.AppendLabels(pt, target)
 			}
+			// 更改分发方式，通过ident分发
+			writer.Writers.PushIdentChan(host, pt)
+		} else {
+			// 如果没有则默认放入指标名前缀的chan中
+			ident := arr[i].Metric[0:strings.Index(arr[i].Metric, "_")]
+			writer.Writers.PushIdentChan(ident, pt)
 		}
 
-		list = append(list, pt)
 		succ++
 	}
 
-	if len(list) > 0 {
-		promstat.CounterSampleTotal.WithLabelValues(config.C.ClusterName, "opentsdb").Add(float64(len(list)))
-		if !writer.Writers.PushQueue(list) {
-			msg = "writer queue full"
-		}
+	if succ > 0 {
+		promstat.CounterSampleTotal.WithLabelValues(config.C.ClusterName, "opentsdb").Add(float64(succ))
 
 		idents.Idents.MSet(ids)
 	}


### PR DESCRIPTION
起因：我们遇到了多个几千个收集的targets，使得n9e发送到prometheus的效果不是很好。
想法：由于每个采集点都有一个ident，这样n9e处理的有些慢。
改造：默认提取ident，每个ident都有一个chan进行分发处理，提升消费效率。
