### PR TITLE
src/pkg/ibex: fix dropped error

### DIFF
--- a/src/pkg/ibex/ibex.go
+++ b/src/pkg/ibex/ibex.go
@@ -103,9 +103,10 @@ func (i *Ibex) do() error {
 
 	var req *http.Request
 	var err error
+	var bs []byte
 
 	if i.inValue != nil {
-		bs, err := json.Marshal(i.inValue)
+		bs, err = json.Marshal(i.inValue)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes an `err` variable in `src/pkg/ibex` that was being redeclared with an `:=` inside an `if` block and lost before it could be returned.