### PR TITLE
fix dashboard name

### DIFF
--- a/src/webapi/router/router_builtin.go
+++ b/src/webapi/router/router_builtin.go
@@ -30,7 +30,7 @@ func alertRuleBuiltinList(c *gin.Context) {
 			continue
 		}
 
-		name := strings.TrimRight(f, ".json")
+		name := strings.TrimSuffix(f, ".json")
 		names = append(names, name)
 	}
 
@@ -103,7 +103,7 @@ func dashboardBuiltinList(c *gin.Context) {
 			continue
 		}
 
-		name := strings.TrimRight(f, ".json")
+		name := strings.TrimSuffix(f, ".json")
 		names = append(names, name)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
fix

**Which issue(s) this PR fixes**:
Fixes # 修复dashboard文件名被截断问题。xxx_by_business变成了xxx_by_busine
 
**Special notes for your reviewer**:
```
fmt.Println("TrimRight: ", strings.TrimRight("xxx_by_business.json", ".json"))
fmt.Println("TrimSuffix: ", strings.TrimSuffix("xxx_by_business.json", ".json"))

TrimRight:  xxx_by_busine
TrimSuffix:  xxx_by_business
```