### PR TITLE
perf: 合并targets_up指标为一个ident，减少资源利用。

### DIFF
--- a/src/server/idents/idents.go
+++ b/src/server/idents/idents.go
@@ -168,7 +168,7 @@ func pushMetrics() {
 			common.AppendLabels(pt, target)
 		}
 
-		writer.Writers.PushSample(active, pt)
+		writer.Writers.PushSample("default_ident_target_up", pt)
 	}
 
 	// 把actives传给TargetCache，看看除了active的部分，还有别的target么？有的话返回，设置target_up = 0
@@ -193,6 +193,6 @@ func pushMetrics() {
 		})
 
 		common.AppendLabels(pt, dead)
-		writer.Writers.PushSample(ident, pt)
+		writer.Writers.PushSample("default_ident_target_up", pt)
 	}
 }


### PR DESCRIPTION
合并可以减少请求次数，其实并需要每个target_up都用一个ident的消费者去处理，这样会导致ident闲置时，每次只发1条数据到prometheus。

![image](https://user-images.githubusercontent.com/14229565/163562195-978fc7a0-964a-411c-b0cb-8930782425e5.png)
